### PR TITLE
Padding for header views (fixed with dynamic section headers using autolayout)..

### DIFF
--- a/NYPLCardCreator/Classes/ConfirmValidAddressViewController.swift
+++ b/NYPLCardCreator/Classes/ConfirmValidAddressViewController.swift
@@ -58,7 +58,6 @@ final class ConfirmValidAddressViewController: TableViewController {
     }
     
     self.tableView.allowsSelection = false
-    self.tableView.tableHeaderView = self.headerLabel
     
     self.navigationItem.rightBarButtonItem =
       UIBarButtonItem(title: NSLocalizedString(
@@ -69,18 +68,6 @@ final class ConfirmValidAddressViewController: TableViewController {
                       action: #selector(addressConfirmed))
   }
   
-  override func viewDidLayoutSubviews() {
-    let origin_x = self.tableView.tableHeaderView!.frame.origin.x
-    let origin_y = self.tableView.tableHeaderView!.frame.origin.y
-    let size = self.tableView.tableHeaderView!.sizeThatFits(CGSize(width: self.view.bounds.width, height: CGFloat.greatestFiniteMagnitude))
-    
-    let adjustedWidth = (size.width > CGFloat(375)) ? CGFloat(375.0) : size.width
-    let padding = CGFloat(30.0)
-    self.headerLabel.frame = CGRect(x: origin_x, y: origin_y, width: adjustedWidth, height: size.height + padding)
-    
-    self.tableView.tableHeaderView = self.headerLabel
-  }
-  
   // MARK: UITableViewDataSource
   
   func numberOfSectionsInTableView(_ tableView: UITableView) -> Int {
@@ -89,6 +76,24 @@ final class ConfirmValidAddressViewController: TableViewController {
   
   override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
     return 1
+  }
+  
+  func tableView(_ tableView: UITableView, estimatedHeightForHeaderInSection section: Int) -> CGFloat {
+    return 44
+  }
+  
+  func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+    return UITableViewAutomaticDimension
+  }
+  
+  func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+    let containerView = UIView()
+    containerView.addSubview(self.headerLabel)
+    self.headerLabel.autoPinEdge(toSuperviewMargin: .left)
+    self.headerLabel.autoPinEdge(toSuperviewMargin: .right)
+    self.headerLabel.autoPinEdge(toSuperviewEdge: .top, withInset: 20)
+    self.headerLabel.autoPinEdge(toSuperviewEdge: .bottom, withInset: 20)
+    return containerView
   }
   
   override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {

--- a/NYPLCardCreator/Classes/UserCredentialsViewController.swift
+++ b/NYPLCardCreator/Classes/UserCredentialsViewController.swift
@@ -5,7 +5,7 @@ import UIKit
 final class UserCredentialsViewController: TableViewController {
   fileprivate var cells: [UITableViewCell]
   fileprivate let headerLabel: UILabel
-  fileprivate var activityView: UIView
+  fileprivate var activityView: ActivityTitleView
   fileprivate let cardType: CardType
   
   fileprivate let configuration: CardCreatorConfiguration
@@ -35,7 +35,11 @@ final class UserCredentialsViewController: TableViewController {
     self.cardType = cardType
     
     self.headerLabel = UILabel()
-    self.activityView = UIView()
+    self.activityView = ActivityTitleView(title:
+      NSLocalizedString(
+        "Signing In...",
+        comment: "A title telling the user that the app is busy signing in with the new account that was just created."))
+    self.activityView.isHidden = true
     
     self.usernameCell = SummaryCell(section: NSLocalizedString("Username", comment: "Title of the section for the user's chosen username"),
                                     cellText: self.username)
@@ -114,11 +118,8 @@ final class UserCredentialsViewController: TableViewController {
   
   override func viewDidAppear(_ animated: Bool) {
     super.viewWillAppear(animated)
-//    self.configuration.completionHandler(self.username, self.pin, false)
-    self.activityView = ActivityTitleView(title:
-      NSLocalizedString(
-      "Signing In...",
-      comment: "A title telling the user that the app is busy signing in with the new account that was just created."))
+    self.configuration.completionHandler(self.username, self.pin, false)
+    self.activityView.isHidden = false
   }
   
   fileprivate func prepareTableViewCells() {
@@ -165,10 +166,8 @@ final class UserCredentialsViewController: TableViewController {
     let containerView = UIView()
     containerView.addSubview(self.headerLabel)
     containerView.addSubview(self.activityView)
-    self.activityView.autoPinEdge(toSuperviewMargin: .left)
-    self.activityView.autoPinEdge(toSuperviewMargin: .right)
+    self.activityView.autoAlignAxis(toSuperviewAxis: .vertical)
     self.activityView.autoPinEdge(toSuperviewEdge: .top, withInset: 16)
-//    self.activityView.autoPinEdge(.bottom, to: .bottom, of: self.activityView, withOffset: 8)
     self.headerLabel.autoPinEdge(toSuperviewMargin: .left)
     self.headerLabel.autoPinEdge(toSuperviewMargin: .right)
     self.headerLabel.autoPinEdge(.top, to: .bottom, of: self.activityView, withOffset: 16)

--- a/NYPLCardCreator/Classes/UserSummaryViewController.swift
+++ b/NYPLCardCreator/Classes/UserSummaryViewController.swift
@@ -117,19 +117,6 @@ final class UserSummaryViewController: TableViewController {
 
     self.tableView.estimatedRowHeight = 120
     self.tableView.allowsSelection = false
-    self.tableView.tableHeaderView = headerLabel
-  }
-  
-  override func viewDidLayoutSubviews() {
-    let origin_x = self.tableView.tableHeaderView!.frame.origin.x
-    let origin_y = self.tableView.tableHeaderView!.frame.origin.y
-    let size = self.tableView.tableHeaderView!.sizeThatFits(CGSize(width: self.view.bounds.width, height: CGFloat.greatestFiniteMagnitude))
-    
-    let adjustedWidth = (size.width > CGFloat(375)) ? CGFloat(375.0) : size.width
-    let padding = CGFloat(30.0)
-    self.headerLabel.frame = CGRect(x: origin_x, y: origin_y, width: adjustedWidth, height: size.height + padding)
-    
-    self.tableView.tableHeaderView = self.headerLabel
   }
   
   fileprivate func prepareTableViewCells() {
@@ -159,7 +146,33 @@ final class UserSummaryViewController: TableViewController {
   }
   
   func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-    return 0
+    if section == 0 {
+      return UITableViewAutomaticDimension
+    } else {
+      return 0
+    }
+  }
+  
+  func tableView(_ tableView: UITableView, estimatedHeightForHeaderInSection section: Int) -> CGFloat {
+    if section == 0 {
+      return 40
+    } else {
+      return 0
+    }
+  }
+  
+  func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+    if section == 0 {
+      let containerView = UIView()
+      containerView.addSubview(self.headerLabel)
+      self.headerLabel.autoPinEdge(toSuperviewMargin: .left)
+      self.headerLabel.autoPinEdge(toSuperviewMargin: .right)
+      self.headerLabel.autoPinEdge(toSuperviewEdge: .top, withInset: 20)
+      self.headerLabel.autoPinEdge(toSuperviewEdge: .bottom, withInset: 20)
+      return containerView
+    } else {
+      return nil
+    }
   }
   
   func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {


### PR DESCRIPTION
Created dynamic table view section headers with autolayout for Card Creator summary screens.

fixes #4 

![card creator autolayout header 1](https://cloud.githubusercontent.com/assets/6179695/24124919/4f7c5b32-0d9c-11e7-9eff-9e0440584426.png)
![card creator autolayout header 2](https://cloud.githubusercontent.com/assets/6179695/24124920/4f7d0a78-0d9c-11e7-93a2-98aec051975a.png)
