### PR TITLE
Add autofill/autosuggest feature to Card Creator form fields #16

### DIFF
--- a/NYPLCardCreator/AddressViewController.swift
+++ b/NYPLCardCreator/AddressViewController.swift
@@ -114,6 +114,14 @@ final class AddressViewController: FormTableViewController {
     self.zipCell.textField.addTarget(self,
                                      action: #selector(zipTextFieldDidChange),
                                      for: .allEditingEvents)
+
+    if #available(iOS 10.0, *) {
+      self.street1Cell.textField.textContentType = .streetAddressLine1
+      self.street2Cell.textField.textContentType = .streetAddressLine2
+      self.cityCell.textField.textContentType    = .addressCity
+      self.regionCell.textField.textContentType  = .addressState
+      self.zipCell.textField.textContentType     = .postalCode
+    }
   }
   
   func checkToPrefillForm() {

--- a/NYPLCardCreator/NameAndEmailViewController.swift
+++ b/NYPLCardCreator/NameAndEmailViewController.swift
@@ -81,6 +81,13 @@ final class NameAndEmailViewController: FormTableViewController {
     self.emailCell.textField.keyboardType = .emailAddress
     self.emailCell.textField.autocapitalizationType = .none
     self.emailCell.textField.autocorrectionType = .no
+
+    if #available(iOS 10.0, *) {
+      self.firstNameCell.textField.textContentType     = .givenName
+      self.middleInitialCell.textField.textContentType = .middleName
+      self.lastNameCell.textField.textContentType      = .familyName
+      self.emailCell.textField.textContentType         = .emailAddress
+    }
   }
   
   func checkToPrefillForm() {


### PR DESCRIPTION
This PR addresses issue #16 , by adding the autofill feature to the fields of the Home Address and Personal Information screens in CardCreator. The following iPad screen shots demonstrate the new autofill feature.


![homeaddress](https://user-images.githubusercontent.com/1022275/29725025-f494b51c-8987-11e7-9b74-94fbf317ca32.PNG)
![personalinformation](https://user-images.githubusercontent.com/1022275/29725030-f8e35e16-8987-11e7-8181-69e9786f8b01.PNG)

 