### PR TITLE
SIMPLY-2722 Refactor first screen to use in Juvenile flow

### DIFF
--- a/NYPLCardCreator.xcodeproj/project.pbxproj
+++ b/NYPLCardCreator.xcodeproj/project.pbxproj
@@ -332,10 +332,9 @@
 			};
 			buildConfigurationList = 607FACCB1AFB9204008FA782 /* Build configuration list for PBXProject "NYPLCardCreator" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
-				English,
 				en,
 				Base,
 			);

--- a/NYPLCardCreator/Helpers/ResultErrors.swift
+++ b/NYPLCardCreator/Helpers/ResultErrors.swift
@@ -13,10 +13,10 @@ public enum Result<T> {
   case fail(Error)
 }
 
-let CardCreatorDomain = "org.nypl.cardcreator"
+public let ErrorDomain = "org.nypl.cardcreator"
 
 /// Error codes related to Card Creator functionality.
-@objc enum ErrorCode: Int {
+public enum ErrorCode: Int {
   case ignore = 0
 
   // business logic errors


### PR DESCRIPTION
I considered creating a completely separate VC for the juvenile flow, but one requirement we have is that it should look/feel the same as the regular one. After a few renames, the complexity added to the existing VC seemed minor enough. The advantage of having one VC is also a simplified handling at the call site.