### PR TITLE
[iOS-119] Reference UIImage to local bundle

### DIFF
--- a/NYPLCardCreator.xcodeproj/project.pbxproj
+++ b/NYPLCardCreator.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		14E61C8520DD7D6F00124E2B /* PureLayout.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 14E61C8320DD7D2000124E2B /* PureLayout.framework */; };
 		14E61C8620DD7E6A00124E2B /* PureLayout.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 14E61C8320DD7D2000124E2B /* PureLayout.framework */; };
 		14E61C8720DD7E6A00124E2B /* PureLayout.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 14E61C8320DD7D2000124E2B /* PureLayout.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		1744DF5A264237EA00CBAAA8 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 607FACDC1AFB9204008FA782 /* Images.xcassets */; };
 		2D6F7C391D90FB3A000B906A /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 2D6F7C381D90FB3A000B906A /* InfoPlist.strings */; };
 		607FACD61AFB9204008FA782 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FACD51AFB9204008FA782 /* AppDelegate.swift */; };
 		607FACDD1AFB9204008FA782 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 607FACDC1AFB9204008FA782 /* Images.xcassets */; };
@@ -426,6 +427,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1744DF5A264237EA00CBAAA8 /* Images.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/NYPLCardCreator/Flow/IntroductionViewController.swift
+++ b/NYPLCardCreator/Flow/IntroductionViewController.swift
@@ -269,12 +269,13 @@ final class IntroductionViewController: UIViewController, UITableViewDelegate, U
   }
   
   private func setCheckmark(_ state: Bool, forCell cell: UITableViewCell?) {
+    let bundle = Bundle(for: type(of: self))
     if (state == true) {
-      cell?.accessoryView = UIImageView(image: UIImage(named: "CheckboxOn"))
+      cell?.accessoryView = UIImageView(image: UIImage(named: "CheckboxOn", in: bundle, compatibleWith: nil))
       cell?.accessibilityLabel = NSLocalizedString("Checkbox is marked", comment: "Accessible label for the current status of the item")
       cell?.accessibilityHint = NSLocalizedString("Select to remove the checkmark", comment: "Accessible label to help give context to the item")
     } else {
-      cell?.accessoryView = UIImageView(image: UIImage(named: "CheckboxOff"))
+      cell?.accessoryView = UIImageView(image: UIImage(named: "CheckboxOff", in: bundle, compatibleWith: nil))
       cell?.accessibilityLabel = NSLocalizedString("Checkbox is not marked", comment: "Accessible label for the current status of the item")
       cell?.accessibilityHint = NSLocalizedString("Select to add a checkmark", comment: "Accessible label to help give context to the item")
     }


### PR DESCRIPTION
**What's this do?**
Fix checkboxes not displayed in CardCreator
PS: The checkbox images originally live in `Simplified-iOS` code base, but they were removed during when we implemented the new AgeGate. This fix makes sure the `UIImage` look for images within the local bundle.

**Why are we doing this? (w/ JIRA link if applicable)**
[iOS-119](https://jira.nypl.org/browse/IOS-119)

**How should this be tested? / Do these changes have associated tests?**
Needed to be test on SimplyE

**Dependencies for merging? Releasing to production?**
N/A

**Does this include changes that require a new SimplyE build for QA?**
No

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@ErnestFan 
