### PR TITLE
iOS-247 Add dark mode support

### DIFF
--- a/NYPLCardCreator.xcodeproj/project.pbxproj
+++ b/NYPLCardCreator.xcodeproj/project.pbxproj
@@ -37,6 +37,10 @@
 		14E61C8120DD7C6200124E2B /* LocationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 146E47B720DD746300C8F97F /* LocationViewController.swift */; };
 		14E61C8220DD7C6200124E2B /* LabelledTextViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 146E47BB20DD746300C8F97F /* LabelledTextViewCell.swift */; };
 		1744DF5A264237EA00CBAAA8 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 607FACDC1AFB9204008FA782 /* Images.xcassets */; };
+		1754096E26FE7F3400B8E077 /* Colors.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1754096D26FE7F3400B8E077 /* Colors.xcassets */; };
+		1754096F26FE7F3400B8E077 /* Colors.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1754096D26FE7F3400B8E077 /* Colors.xcassets */; };
+		1754097326FE7FD900B8E077 /* NYPLColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1754097226FE7FD900B8E077 /* NYPLColor.swift */; };
+		1754097426FE7FD900B8E077 /* NYPLColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1754097226FE7FD900B8E077 /* NYPLColor.swift */; };
 		1760C2CA2646096C0087C28C /* PureLayout.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 176F5BCD2644D28D002CBA0E /* PureLayout.xcframework */; };
 		176F5BCE2644D28D002CBA0E /* PureLayout.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 176F5BCD2644D28D002CBA0E /* PureLayout.xcframework */; };
 		176F5BCF2644D28D002CBA0E /* PureLayout.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 176F5BCD2644D28D002CBA0E /* PureLayout.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -125,6 +129,8 @@
 		14E61C5E20DD7C4800124E2B /* NYPLCardCreator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NYPLCardCreator.h; sourceTree = "<group>"; };
 		14E61C5F20DD7C4800124E2B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		14E61C8320DD7D2000124E2B /* PureLayout.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = PureLayout.framework; path = Carthage/Build/iOS/PureLayout.framework; sourceTree = "<group>"; };
+		1754096D26FE7F3400B8E077 /* Colors.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Colors.xcassets; sourceTree = "<group>"; };
+		1754097226FE7FD900B8E077 /* NYPLColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLColor.swift; sourceTree = "<group>"; };
 		176F5BCD2644D28D002CBA0E /* PureLayout.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = PureLayout.xcframework; path = Carthage/Build/PureLayout.xcframework; sourceTree = "<group>"; };
 		2D6F7C381D90FB3A000B906A /* InfoPlist.strings */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = InfoPlist.strings; path = ../NYPLCardCreatorExample/InfoPlist.strings; sourceTree = "<group>"; };
 		607FACD01AFB9204008FA782 /* NYPLCardCreator_Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = NYPLCardCreator_Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -213,6 +219,7 @@
 				607FACDC1AFB9204008FA782 /* Images.xcassets */,
 				607FACDE1AFB9204008FA782 /* LaunchScreen.xib */,
 				607FACD31AFB9204008FA782 /* Supporting Files */,
+				1754096D26FE7F3400B8E077 /* Colors.xcassets */,
 			);
 			name = NYPLCardCreatorExample;
 			path = NYPLCardCreator;
@@ -284,6 +291,7 @@
 				146E47B220DD746300C8F97F /* AuthenticatingSession.swift */,
 				146E47BD20DD746300C8F97F /* CardType.swift */,
 				7353354C246DBB8D000C2874 /* ResultErrors.swift */,
+				1754097226FE7FD900B8E077 /* NYPLColor.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -430,6 +438,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				1744DF5A264237EA00CBAAA8 /* Images.xcassets in Resources */,
+				1754096E26FE7F3400B8E077 /* Colors.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -438,6 +447,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				607FACE01AFB9204008FA782 /* LaunchScreen.xib in Resources */,
+				1754096F26FE7F3400B8E077 /* Colors.xcassets in Resources */,
 				2D6F7C391D90FB3A000B906A /* InfoPlist.strings in Resources */,
 				607FACDD1AFB9204008FA782 /* Images.xcassets in Resources */,
 			);
@@ -461,6 +471,7 @@
 				14E61C6F20DD7C6200124E2B /* RemoteHTMLViewController.swift in Sources */,
 				14E61C6C20DD7C6200124E2B /* ActivityTitleView.swift in Sources */,
 				14E61C7320DD7C6200124E2B /* FormTableViewController.swift in Sources */,
+				1754097326FE7FD900B8E077 /* NYPLColor.swift in Sources */,
 				14E61C7C20DD7C6200124E2B /* NameAndEmailViewController.swift in Sources */,
 				14E61C6A20DD7C6200124E2B /* CardCreator.swift in Sources */,
 				14E61C7420DD7C6200124E2B /* PlacemarkQuery.swift in Sources */,
@@ -496,6 +507,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1754097426FE7FD900B8E077 /* NYPLColor.swift in Sources */,
 				607FACD61AFB9204008FA782 /* AppDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/NYPLCardCreator/Colors.xcassets/Contents.json
+++ b/NYPLCardCreator/Colors.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/NYPLCardCreator/Colors.xcassets/action.colorset/Contents.json
+++ b/NYPLCardCreator/Colors.xcassets/action.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0x9A",
+          "red" : "0x00"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0x9A",
+          "red" : "0x00"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/NYPLCardCreator/Colors.xcassets/disabledFieldText.colorset/Contents.json
+++ b/NYPLCardCreator/Colors.xcassets/disabledFieldText.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x66",
+          "green" : "0x63",
+          "red" : "0x63"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xA1",
+          "green" : "0x99",
+          "red" : "0x99"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/NYPLCardCreator/Colors.xcassets/primaryBackground.colorset/Contents.json
+++ b/NYPLCardCreator/Colors.xcassets/primaryBackground.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFA",
+          "green" : "0xFA",
+          "red" : "0xFA"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x12",
+          "green" : "0x12",
+          "red" : "0x12"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/NYPLCardCreator/Colors.xcassets/primaryText.colorset/Contents.json
+++ b/NYPLCardCreator/Colors.xcassets/primaryText.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0x00",
+          "red" : "0x00"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/NYPLCardCreator/Flow/AddressViewController.swift
+++ b/NYPLCardCreator/Flow/AddressViewController.swift
@@ -106,7 +106,7 @@ final class AddressViewController: FormTableViewController {
     case .work:
       self.regionCell.textField.isUserInteractionEnabled = false
       self.regionCell.textField.text = "New York"
-      self.regionCell.textField.textColor = UIColor.gray
+      self.regionCell.textField.textColor = NYPLColor.disabledFieldTextColor
     }
     
     self.zipCell.textField.keyboardType = .numberPad

--- a/NYPLCardCreator/Flow/AlternativeAddressesViewController.swift
+++ b/NYPLCardCreator/Flow/AlternativeAddressesViewController.swift
@@ -38,7 +38,7 @@ final class AlternativeAddressesViewController: TableViewController {
     
     headerLabel.numberOfLines = 0
     headerLabel.lineBreakMode = .byWordWrapping
-    headerLabel.textColor = UIColor.darkGray
+    headerLabel.textColor = NYPLColor.disabledFieldTextColor
     headerLabel.textAlignment = .center
     
     switch self.addressStep {

--- a/NYPLCardCreator/Flow/ConfirmValidAddressViewController.swift
+++ b/NYPLCardCreator/Flow/ConfirmValidAddressViewController.swift
@@ -39,7 +39,7 @@ final class ConfirmValidAddressViewController: TableViewController {
     
     headerLabel.numberOfLines = 0
     headerLabel.lineBreakMode = .byWordWrapping
-    headerLabel.textColor = UIColor.darkGray
+    headerLabel.textColor = NYPLColor.disabledFieldTextColor
     headerLabel.textAlignment = .center
 
     switch self.addressStep {

--- a/NYPLCardCreator/Flow/IntroductionViewController.swift
+++ b/NYPLCardCreator/Flow/IntroductionViewController.swift
@@ -28,7 +28,7 @@ final class IntroductionViewController: UIViewController, UITableViewDelegate, U
     super.viewDidLoad()
     
     self.title = configuration.localizedStrings.welcomeTitle
-    self.view.backgroundColor = UIColor.white
+    self.view.backgroundColor = NYPLColor.primaryBackgroundColor
     
     self.tableView = UITableView.init(frame: view.frame, style: .grouped)
     self.tableView.delegate = self
@@ -47,11 +47,7 @@ final class IntroductionViewController: UIViewController, UITableViewDelegate, U
   }
   
   private func setupCustomViews() {
-    if #available(iOS 13.0, *) {
-      self.descriptionLabel.textColor = UIColor.label
-    } else {
-      self.descriptionLabel.textColor = UIColor.gray
-    }
+    self.descriptionLabel.textColor = NYPLColor.primaryTextColor
     self.descriptionLabel.font = UIFont.preferredFont(forTextStyle: UIFont.TextStyle.body)
     self.descriptionLabel.numberOfLines = 0
     self.descriptionLabel.text = configuration.localizedStrings.featureRequirements
@@ -139,13 +135,7 @@ final class IntroductionViewController: UIViewController, UITableViewDelegate, U
       return nil
     }
 
-    let linkColor: UIColor
-    if #available(iOS 13, *) {
-      linkColor = .link
-    } else {
-      linkColor = UIColor(red: 0.05, green: 0.4, blue: 0.65, alpha: 1.0)
-    }
-
+    let linkColor = NYPLColor.actionColor
     let eulaButton = UIButton()
     eulaButton.setTitle(NSLocalizedString("End User License Agreement", comment: "Title of button for EULA"), for: .normal)
     eulaButton.setTitleColor(linkColor, for: .normal)
@@ -271,11 +261,17 @@ final class IntroductionViewController: UIViewController, UITableViewDelegate, U
   private func setCheckmark(_ state: Bool, forCell cell: UITableViewCell?) {
     let bundle = Bundle(for: type(of: self))
     if (state == true) {
-      cell?.accessoryView = UIImageView(image: UIImage(named: "CheckboxOn", in: bundle, compatibleWith: nil))
+      let image = UIImage(named: "CheckboxOn", in: bundle, compatibleWith: nil)?.withRenderingMode(.alwaysTemplate)
+      let imageView = UIImageView(image: image)
+      imageView.tintColor = NYPLColor.primaryTextColor
+      cell?.accessoryView = imageView
       cell?.accessibilityLabel = NSLocalizedString("Checkbox is marked", comment: "Accessible label for the current status of the item")
       cell?.accessibilityHint = NSLocalizedString("Select to remove the checkmark", comment: "Accessible label to help give context to the item")
     } else {
-      cell?.accessoryView = UIImageView(image: UIImage(named: "CheckboxOff", in: bundle, compatibleWith: nil))
+      let image = UIImage(named: "CheckboxOff", in: bundle, compatibleWith: nil)?.withRenderingMode(.alwaysTemplate)
+      let imageView = UIImageView(image: image)
+      imageView.tintColor = NYPLColor.primaryTextColor
+      cell?.accessoryView = imageView
       cell?.accessibilityLabel = NSLocalizedString("Checkbox is not marked", comment: "Accessible label for the current status of the item")
       cell?.accessibilityHint = NSLocalizedString("Select to add a checkmark", comment: "Accessible label to help give context to the item")
     }

--- a/NYPLCardCreator/Flow/LocationViewController.swift
+++ b/NYPLCardCreator/Flow/LocationViewController.swift
@@ -5,7 +5,7 @@ final class LocationViewController: UIViewController {
   
   private let configuration: CardCreatorConfiguration
   
-  private let activityIndicatorView = UIActivityIndicatorView(style: .gray)
+  private let activityIndicatorView = UIActivityIndicatorView()
   private var observers: [NSObjectProtocol] = []
   private let resultLabel = UILabel()
   private var placemarkQuery: PlacemarkQuery? = nil
@@ -43,16 +43,17 @@ final class LocationViewController: UIViewController {
                                      action: nil)
     self.navigationItem.backBarButtonItem = backButton
     
-    self.view.backgroundColor = UIColor.white
+    self.view.backgroundColor = NYPLColor.primaryBackgroundColor
     
     self.view.addSubview(self.activityIndicatorView)
     self.activityIndicatorView.autoCenterInSuperview()
+    self.activityIndicatorView.color = NYPLColor.disabledFieldTextColor
     
     self.view.addSubview(self.resultLabel)
     self.resultLabel.isHidden = true
     self.resultLabel.autoPinEdgesToSuperviewMargins()
     self.resultLabel.numberOfLines = 0
-    self.resultLabel.textColor = UIColor.darkGray
+    self.resultLabel.textColor = NYPLColor.disabledFieldTextColor
     self.resultLabel.textAlignment = .center
     
     self.navigationItem.rightBarButtonItem =

--- a/NYPLCardCreator/Flow/UserCredentialsViewController.swift
+++ b/NYPLCardCreator/Flow/UserCredentialsViewController.swift
@@ -69,7 +69,7 @@ final class UserCredentialsViewController: TableViewController {
   override func viewDidLoad() {
     super.viewDidLoad()
     
-    self.tableView.backgroundColor = UIColor.groupTableViewBackground
+    self.tableView.backgroundColor = NYPLColor.primaryBackgroundColor
 
     self.title = NSLocalizedString(
       "Your Card Information",
@@ -94,7 +94,7 @@ final class UserCredentialsViewController: TableViewController {
     
     headerLabel.numberOfLines = 0
     headerLabel.lineBreakMode = .byWordWrapping
-    headerLabel.textColor = UIColor.darkGray
+    headerLabel.textColor = NYPLColor.disabledFieldTextColor
     headerLabel.textAlignment = .center
     
     self.tableView.estimatedRowHeight = 120

--- a/NYPLCardCreator/Flow/UserSummaryViewController.swift
+++ b/NYPLCardCreator/Flow/UserSummaryViewController.swift
@@ -121,7 +121,7 @@ final class UserSummaryViewController: TableViewController, JuvenileCardCreation
   override func viewDidLoad() {
     super.viewDidLoad()
     
-    self.tableView.backgroundColor = UIColor.groupTableViewBackground
+    self.tableView.backgroundColor = NYPLColor.primaryBackgroundColor
     
     self.title = NSLocalizedString(
       "Review",
@@ -129,7 +129,7 @@ final class UserSummaryViewController: TableViewController, JuvenileCardCreation
     
     headerLabel.numberOfLines = 0
     headerLabel.lineBreakMode = .byWordWrapping
-    headerLabel.textColor = UIColor.darkGray
+    headerLabel.textColor = NYPLColor.disabledFieldTextColor
     headerLabel.textAlignment = .center
     
     headerLabel.text = NSLocalizedString(

--- a/NYPLCardCreator/Helpers/NYPLColor.swift
+++ b/NYPLCardCreator/Helpers/NYPLColor.swift
@@ -1,0 +1,63 @@
+//
+//  NYPLColor.swift
+//  NYPLCardCreator
+//
+//  Created by Ernest Fan on 2021-09-24.
+//  Copyright © 2021 NYPL Labs. All rights reserved.
+//
+
+import UIKit
+
+private enum ColorAsset: String {
+  case primaryBackground
+  case primaryText
+  case action
+  case disabledFieldText
+}
+
+class NYPLColor {
+  static var primaryBackgroundColor: UIColor {
+    if #available(iOS 13.0, *),
+       UIScreen.main.traitCollection.userInterfaceStyle == .light {
+      return .systemBackground
+    } else if #available(iOS 11.0, *),
+       let color = UIColor(named: ColorAsset.primaryBackground.rawValue) {
+      return color
+    }
+
+    return .white
+  }
+  
+  static var primaryTextColor: UIColor {
+    if #available(iOS 13.0, *),
+       UIScreen.main.traitCollection.userInterfaceStyle == .light {
+      return .label
+    } else if #available(iOS 11.0, *),
+       let color = UIColor(named: ColorAsset.primaryText.rawValue) {
+      return color
+    }
+
+    return .black
+  }
+  
+  static var actionColor: UIColor {
+    if #available(iOS 13.0, *),
+       UIScreen.main.traitCollection.userInterfaceStyle == .light {
+      return .link
+    } else if #available(iOS 11.0, *),
+       let color = UIColor(named: ColorAsset.action.rawValue) {
+      return color
+    }
+
+    return .systemBlue
+  }
+  
+  static var disabledFieldTextColor: UIColor {
+    if #available(iOS 11.0, *),
+       let color = UIColor(named: ColorAsset.disabledFieldText.rawValue) {
+      return color
+    }
+
+    return .lightGray
+  }
+}

--- a/NYPLCardCreator/ReusedUIComponents/ActivityTitleView.swift
+++ b/NYPLCardCreator/ReusedUIComponents/ActivityTitleView.swift
@@ -10,7 +10,8 @@ final class ActivityTitleView: UIView {
     
     let padding: CGFloat = 5.0
     
-    let activityIndicatorView = UIActivityIndicatorView(style: .gray)
+    let activityIndicatorView = UIActivityIndicatorView()
+    activityIndicatorView.color = NYPLColor.disabledFieldTextColor
     activityIndicatorView.startAnimating()
     self.addSubview(activityIndicatorView)
     activityIndicatorView.autoPinEdgesToSuperviewEdges(with: UIEdgeInsets.zero, excludingEdge: .right)

--- a/NYPLCardCreator/ReusedUIComponents/RemoteHTMLViewController.swift
+++ b/NYPLCardCreator/ReusedUIComponents/RemoteHTMLViewController.swift
@@ -32,7 +32,7 @@ final class RemoteHTMLViewController: UIViewController, WKNavigationDelegate {
   override func viewDidLoad() {
     webView.frame = self.view.frame
     webView.navigationDelegate = self
-    webView.backgroundColor = UIColor.white
+    webView.backgroundColor = NYPLColor.primaryBackgroundColor
     webView.allowsBackForwardNavigationGestures = true
 
     view.addSubview(self.webView)
@@ -46,7 +46,8 @@ final class RemoteHTMLViewController: UIViewController, WKNavigationDelegate {
   
   func activityView(_ animated: Bool) -> Void {
     if animated == true {
-      activityView = UIActivityIndicatorView.init(style: .gray)
+      activityView = UIActivityIndicatorView.init()
+      activityView.color = NYPLColor.disabledFieldTextColor
       activityView.center = self.view.center
       view.addSubview(activityView)
       activityView.startAnimating()

--- a/NYPLCardCreator/ReusedUIComponents/SummaryAddressCell.swift
+++ b/NYPLCardCreator/ReusedUIComponents/SummaryAddressCell.swift
@@ -37,7 +37,7 @@ final class SummaryAddressCell: UITableViewCell {
     //Style labels
     self.sectionLabel.text = section
     self.sectionLabel.text  = self.sectionLabel.text?.uppercased()
-    self.sectionLabel.textColor = UIColor.darkGray
+    self.sectionLabel.textColor = NYPLColor.disabledFieldTextColor
     self.sectionLabel.font = UIFont(name: "AvenirNext-Regular", size: 14)
     
     self.contentView.addSubview(self.sectionLabel)

--- a/NYPLCardCreator/ReusedUIComponents/SummaryCell.swift
+++ b/NYPLCardCreator/ReusedUIComponents/SummaryCell.swift
@@ -17,7 +17,7 @@ final class SummaryCell: UITableViewCell {
     self.cellLabel.text = cellText
     
     self.sectionLabel.text  = self.sectionLabel.text?.uppercased()
-    self.sectionLabel.textColor = UIColor.darkGray
+    self.sectionLabel.textColor = NYPLColor.disabledFieldTextColor
     self.sectionLabel.font = UIFont(name: "AvenirNext-Regular", size: 14)
     
     self.contentView.addSubview(self.sectionLabel)

--- a/NYPLCardCreatorExample/AppDelegate.swift
+++ b/NYPLCardCreatorExample/AppDelegate.swift
@@ -13,7 +13,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate
   {
     self.window = UIWindow.init(frame: UIScreen.main.bounds)
     self.window?.rootViewController = UIViewController()
-    self.window?.rootViewController?.view.backgroundColor = UIColor.white
+    self.window?.rootViewController?.view.backgroundColor = NYPLColor.primaryBackgroundColor
     self.window?.tintAdjustmentMode = .normal;
     self.window?.makeKeyAndVisible()
     


### PR DESCRIPTION
**What's this do?**
Update UI with dark mode color palette

**Why are we doing this? (w/ JIRA link if applicable)**
[ios-247](https://jira.nypl.org/browse/IOS-247)

**How should this be tested? / Do these changes have associated tests?**
Make sure the UI matches the one in [figma](https://www.figma.com/file/SbU22GePd2pXUQ5yrauF15/Dark-Mode?node-id=208%3A37)

**Dependencies for merging? Releasing to production?**
N/A

**Does this include changes that require a new SimplyE/Open eBooks build for QA?**
Will do later

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@ErnestFan tested with CardCreator-Example and SE
