### PR TITLE
IOS-278 'Fix' simulator build on arm64 Macs

### DIFF
--- a/NYPLCardCreator.xcodeproj/project.pbxproj
+++ b/NYPLCardCreator.xcodeproj/project.pbxproj
@@ -584,6 +584,7 @@
 					"@loader_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.2;
+				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = org.nypl.labs.NYPLCardCreator;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;


### PR DESCRIPTION
On an apple silicon macs this will include an arm64 slice together with intel slices for simulator builds.