### PR TITLE
iOS-232 Implement password validation and update address validation API

### DIFF
--- a/NYPLCardCreator.xcodeproj/project.pbxproj
+++ b/NYPLCardCreator.xcodeproj/project.pbxproj
@@ -44,6 +44,8 @@
 		1760C2CA2646096C0087C28C /* PureLayout.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 176F5BCD2644D28D002CBA0E /* PureLayout.xcframework */; };
 		176F5BCE2644D28D002CBA0E /* PureLayout.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 176F5BCD2644D28D002CBA0E /* PureLayout.xcframework */; };
 		176F5BCF2644D28D002CBA0E /* PureLayout.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 176F5BCD2644D28D002CBA0E /* PureLayout.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		17B17A96272B9F5400314AF6 /* PasswordValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17B17A95272B9F5400314AF6 /* PasswordValidator.swift */; };
+		17B17A9A272BAE2000314AF6 /* PasswordValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17B17A99272BAE2000314AF6 /* PasswordValidationTests.swift */; };
 		2D6F7C391D90FB3A000B906A /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 2D6F7C381D90FB3A000B906A /* InfoPlist.strings */; };
 		607FACD61AFB9204008FA782 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FACD51AFB9204008FA782 /* AppDelegate.swift */; };
 		607FACDD1AFB9204008FA782 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 607FACDC1AFB9204008FA782 /* Images.xcassets */; };
@@ -132,6 +134,8 @@
 		1754096D26FE7F3400B8E077 /* Colors.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Colors.xcassets; sourceTree = "<group>"; };
 		1754097226FE7FD900B8E077 /* NYPLColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLColor.swift; sourceTree = "<group>"; };
 		176F5BCD2644D28D002CBA0E /* PureLayout.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = PureLayout.xcframework; path = Carthage/Build/PureLayout.xcframework; sourceTree = "<group>"; };
+		17B17A95272B9F5400314AF6 /* PasswordValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordValidator.swift; sourceTree = "<group>"; };
+		17B17A99272BAE2000314AF6 /* PasswordValidationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordValidationTests.swift; sourceTree = "<group>"; };
 		2D6F7C381D90FB3A000B906A /* InfoPlist.strings */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = InfoPlist.strings; path = ../NYPLCardCreatorExample/InfoPlist.strings; sourceTree = "<group>"; };
 		607FACD01AFB9204008FA782 /* NYPLCardCreator_Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = NYPLCardCreator_Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		607FACD41AFB9204008FA782 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = Info.plist; path = ../NYPLCardCreatorExample/Info.plist; sourceTree = "<group>"; };
@@ -279,6 +283,7 @@
 				73D15457247CA58000ACD04E /* PlatformAPIError.swift */,
 				146E47C620DD746300C8F97F /* ValidateAddressResponse.swift */,
 				146E47B820DD746300C8F97F /* ValidateUsernameResponse.swift */,
+				17B17A95272B9F5400314AF6 /* PasswordValidator.swift */,
 			);
 			path = BusinessLogic;
 			sourceTree = "<group>";
@@ -302,6 +307,7 @@
 				73EEE7E3247F274E00A06D14 /* Info.plist */,
 				73EEE7EC247F290700A06D14 /* JuvenileCreationResponseBodyTests.swift */,
 				736D97A42559EB1300843709 /* CardCreatorConfigurationTests.swift */,
+				17B17A99272BAE2000314AF6 /* PasswordValidationTests.swift */,
 			);
 			path = NYPLCardCreatorTests;
 			sourceTree = "<group>";
@@ -470,6 +476,7 @@
 				14E61C7020DD7C6200124E2B /* IntroductionViewController.swift in Sources */,
 				14E61C6F20DD7C6200124E2B /* RemoteHTMLViewController.swift in Sources */,
 				14E61C6C20DD7C6200124E2B /* ActivityTitleView.swift in Sources */,
+				17B17A96272B9F5400314AF6 /* PasswordValidator.swift in Sources */,
 				14E61C7320DD7C6200124E2B /* FormTableViewController.swift in Sources */,
 				1754097326FE7FD900B8E077 /* NYPLColor.swift in Sources */,
 				14E61C7C20DD7C6200124E2B /* NameAndEmailViewController.swift in Sources */,
@@ -516,6 +523,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				17B17A9A272BAE2000314AF6 /* PasswordValidationTests.swift in Sources */,
 				73EEE7ED247F290700A06D14 /* JuvenileCreationResponseBodyTests.swift in Sources */,
 				736D97A52559EB1300843709 /* CardCreatorConfigurationTests.swift in Sources */,
 			);

--- a/NYPLCardCreator.xcodeproj/project.pbxproj
+++ b/NYPLCardCreator.xcodeproj/project.pbxproj
@@ -11,7 +11,6 @@
 		14E61C6320DD7C4800124E2B /* NYPLCardCreator.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 14E61C5C20DD7C4800124E2B /* NYPLCardCreator.framework */; };
 		14E61C6420DD7C4800124E2B /* NYPLCardCreator.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 14E61C5C20DD7C4800124E2B /* NYPLCardCreator.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		14E61C6920DD7C6200124E2B /* Address.swift in Sources */ = {isa = PBXBuildFile; fileRef = 146E47B420DD746300C8F97F /* Address.swift */; };
-		14E61C6A20DD7C6200124E2B /* CardCreator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 146E47B620DD746300C8F97F /* CardCreator.swift */; };
 		14E61C6B20DD7C6200124E2B /* ConfirmValidAddressViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 146E47C420DD746300C8F97F /* ConfirmValidAddressViewController.swift */; };
 		14E61C6C20DD7C6200124E2B /* ActivityTitleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 146E47B020DD746300C8F97F /* ActivityTitleView.swift */; };
 		14E61C6D20DD7C6200124E2B /* CardType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 146E47BD20DD746300C8F97F /* CardType.swift */; };
@@ -44,6 +43,7 @@
 		1760C2CA2646096C0087C28C /* PureLayout.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 176F5BCD2644D28D002CBA0E /* PureLayout.xcframework */; };
 		176F5BCE2644D28D002CBA0E /* PureLayout.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 176F5BCD2644D28D002CBA0E /* PureLayout.xcframework */; };
 		176F5BCF2644D28D002CBA0E /* PureLayout.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 176F5BCD2644D28D002CBA0E /* PureLayout.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		179267E92734D85D004EA5E7 /* FlowCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 179267E82734D85D004EA5E7 /* FlowCoordinator.swift */; };
 		17B17A96272B9F5400314AF6 /* PasswordValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17B17A95272B9F5400314AF6 /* PasswordValidator.swift */; };
 		17B17A9A272BAE2000314AF6 /* PasswordValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17B17A99272BAE2000314AF6 /* PasswordValidationTests.swift */; };
 		2D6F7C391D90FB3A000B906A /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 2D6F7C381D90FB3A000B906A /* InfoPlist.strings */; };
@@ -54,7 +54,7 @@
 		735F6379247DDDB6008858C4 /* JuvenileCreationResponseBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = 735F6378247DDDB6008858C4 /* JuvenileCreationResponseBody.swift */; };
 		736D97A52559EB1300843709 /* CardCreatorConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 736D97A42559EB1300843709 /* CardCreatorConfigurationTests.swift */; };
 		738401032474974000236B0D /* ISSOToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 738401022474974000236B0D /* ISSOToken.swift */; };
-		73935214246CD0C200ACC0AB /* JuvenileFlowCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73935213246CD0C200ACC0AB /* JuvenileFlowCoordinator.swift */; };
+		73935214246CD0C200ACC0AB /* FlowCoordinator+Juvenile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73935213246CD0C200ACC0AB /* FlowCoordinator+Juvenile.swift */; };
 		73D15456247C96C700ACD04E /* JuvenileCreationInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73D15455247C96C700ACD04E /* JuvenileCreationInfo.swift */; };
 		73D15458247CA58000ACD04E /* PlatformAPIError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73D15457247CA58000ACD04E /* PlatformAPIError.swift */; };
 		73EEE7E4247F274E00A06D14 /* NYPLCardCreator.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 14E61C5C20DD7C4800124E2B /* NYPLCardCreator.framework */; };
@@ -107,7 +107,6 @@
 		146E47B320DD746300C8F97F /* SummaryCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryCell.swift; sourceTree = "<group>"; };
 		146E47B420DD746300C8F97F /* Address.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Address.swift; sourceTree = "<group>"; };
 		146E47B520DD746300C8F97F /* AddressStep.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressStep.swift; sourceTree = "<group>"; };
-		146E47B620DD746300C8F97F /* CardCreator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardCreator.swift; sourceTree = "<group>"; };
 		146E47B720DD746300C8F97F /* LocationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationViewController.swift; sourceTree = "<group>"; };
 		146E47B820DD746300C8F97F /* ValidateUsernameResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValidateUsernameResponse.swift; sourceTree = "<group>"; };
 		146E47B920DD746300C8F97F /* PlacemarkQuery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlacemarkQuery.swift; sourceTree = "<group>"; };
@@ -134,6 +133,7 @@
 		1754096D26FE7F3400B8E077 /* Colors.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Colors.xcassets; sourceTree = "<group>"; };
 		1754097226FE7FD900B8E077 /* NYPLColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLColor.swift; sourceTree = "<group>"; };
 		176F5BCD2644D28D002CBA0E /* PureLayout.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = PureLayout.xcframework; path = Carthage/Build/PureLayout.xcframework; sourceTree = "<group>"; };
+		179267E82734D85D004EA5E7 /* FlowCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlowCoordinator.swift; sourceTree = "<group>"; };
 		17B17A95272B9F5400314AF6 /* PasswordValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordValidator.swift; sourceTree = "<group>"; };
 		17B17A99272BAE2000314AF6 /* PasswordValidationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordValidationTests.swift; sourceTree = "<group>"; };
 		2D6F7C381D90FB3A000B906A /* InfoPlist.strings */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = InfoPlist.strings; path = ../NYPLCardCreatorExample/InfoPlist.strings; sourceTree = "<group>"; };
@@ -146,7 +146,7 @@
 		735F6378247DDDB6008858C4 /* JuvenileCreationResponseBody.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JuvenileCreationResponseBody.swift; sourceTree = "<group>"; };
 		736D97A42559EB1300843709 /* CardCreatorConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardCreatorConfigurationTests.swift; sourceTree = "<group>"; };
 		738401022474974000236B0D /* ISSOToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ISSOToken.swift; sourceTree = "<group>"; };
-		73935213246CD0C200ACC0AB /* JuvenileFlowCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JuvenileFlowCoordinator.swift; sourceTree = "<group>"; };
+		73935213246CD0C200ACC0AB /* FlowCoordinator+Juvenile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FlowCoordinator+Juvenile.swift"; sourceTree = "<group>"; };
 		73D15455247C96C700ACD04E /* JuvenileCreationInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JuvenileCreationInfo.swift; sourceTree = "<group>"; };
 		73D15457247CA58000ACD04E /* PlatformAPIError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlatformAPIError.swift; sourceTree = "<group>"; };
 		73EEE7DF247F274E00A06D14 /* NYPLCardCreatorTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = NYPLCardCreatorTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -241,7 +241,6 @@
 		7382032924731A7E00BCFA89 /* Flow */ = {
 			isa = PBXGroup;
 			children = (
-				146E47B620DD746300C8F97F /* CardCreator.swift */,
 				146E47C020DD746300C8F97F /* IntroductionViewController.swift */,
 				146E47B720DD746300C8F97F /* LocationViewController.swift */,
 				146E47C720DD746300C8F97F /* AddressViewController.swift */,
@@ -278,7 +277,8 @@
 				738401022474974000236B0D /* ISSOToken.swift */,
 				73D15455247C96C700ACD04E /* JuvenileCreationInfo.swift */,
 				735F6378247DDDB6008858C4 /* JuvenileCreationResponseBody.swift */,
-				73935213246CD0C200ACC0AB /* JuvenileFlowCoordinator.swift */,
+				179267E82734D85D004EA5E7 /* FlowCoordinator.swift */,
+				73935213246CD0C200ACC0AB /* FlowCoordinator+Juvenile.swift */,
 				146E47B920DD746300C8F97F /* PlacemarkQuery.swift */,
 				73D15457247CA58000ACD04E /* PlatformAPIError.swift */,
 				146E47C620DD746300C8F97F /* ValidateAddressResponse.swift */,
@@ -480,9 +480,9 @@
 				14E61C7320DD7C6200124E2B /* FormTableViewController.swift in Sources */,
 				1754097326FE7FD900B8E077 /* NYPLColor.swift in Sources */,
 				14E61C7C20DD7C6200124E2B /* NameAndEmailViewController.swift in Sources */,
-				14E61C6A20DD7C6200124E2B /* CardCreator.swift in Sources */,
+				179267E92734D85D004EA5E7 /* FlowCoordinator.swift in Sources */,
 				14E61C7420DD7C6200124E2B /* PlacemarkQuery.swift in Sources */,
-				73935214246CD0C200ACC0AB /* JuvenileFlowCoordinator.swift in Sources */,
+				73935214246CD0C200ACC0AB /* FlowCoordinator+Juvenile.swift in Sources */,
 				14E61C7F20DD7C6200124E2B /* UsernameAndPINViewController.swift in Sources */,
 				14E61C7920DD7C6200124E2B /* AddressViewController.swift in Sources */,
 				14E61C7220DD7C6200124E2B /* SummaryCell.swift in Sources */,

--- a/NYPLCardCreator/BusinessLogic/AddressStep.swift
+++ b/NYPLCardCreator/BusinessLogic/AddressStep.swift
@@ -33,11 +33,12 @@ enum AddressStep {
     }
   }
   
-  /// Given a `Configuration`, the current `UIViewController`, an `Address` that has just
+  /// Given a `Configuration`, `authToken`, the current `UIViewController`, an `Address` that has just
   /// been validated, and the `CardType` implied by the validated address, continue with the
   /// registration flow as appropriate.
   func continueFlowWithValidAddress(
     _ configuration: CardCreatorConfiguration,
+    authToken: ISSOToken,
     viewController: UIViewController,
     address: Address,
     cardType: CardType)
@@ -58,7 +59,9 @@ enum AddressStep {
           style: .default,
           handler: {_ in
             viewController.navigationController?.pushViewController(
-              AddressViewController(configuration: configuration, addressStep: .work(homeAddress: address)),
+              AddressViewController(configuration: configuration,
+                                    authToken: authToken,
+                                    addressStep: .work(homeAddress: address)),
               animated: true)
         }))
         alertController.addAction(UIAlertAction(
@@ -66,7 +69,9 @@ enum AddressStep {
           style: .default,
           handler: {_ in
             viewController.navigationController?.pushViewController(
-              AddressViewController(configuration: configuration, addressStep: .school(homeAddress: address)),
+              AddressViewController(configuration: configuration,
+                                    authToken: authToken,
+                                    addressStep: .school(homeAddress: address)),
               animated: true)
         }))
         alertController.addAction(UIAlertAction(
@@ -111,6 +116,7 @@ enum AddressStep {
       let (homeAddress, schoolOrWorkAddress) = self.pairWithAppendedAddress(address)
       let nameAndEmailViewController = NameAndEmailViewController(
         configuration: configuration,
+        authToken: authToken,
         homeAddress: homeAddress,
         schoolOrWorkAddress: schoolOrWorkAddress,
         cardType: cardType)

--- a/NYPLCardCreator/BusinessLogic/CardCreatorConfiguration.swift
+++ b/NYPLCardCreator/BusinessLogic/CardCreatorConfiguration.swift
@@ -1,8 +1,7 @@
 import UIKit
 
 /// The information regarding the 2nd version of the card creator api. This is
-/// currently used only for the Juvenile cards but in the future it will be
-/// used for regular patron cards too.
+/// currently used for both regular and Juvenile card creation.
 public final class NYPLPlatformAPIInfo: NSObject {
   let oauthTokenURL: URL
   let clientID: String
@@ -40,10 +39,10 @@ public final class CardCreatorConfiguration: NSObject {
   /// The password to be provided via basic authentication to the API endpoint.
   public let endpointPassword: String
 
-  /// Currently necessary only for the Juvenile flow.
+  /// Necessary for both regular and Juvenile flow.
   /// - Note: At some point in the future this will also include `endpointURL`,
   /// `endpointUsername`, `endpointPassword`.
-  let platformAPIInfo: NYPLPlatformAPIInfo?
+  let platformAPIInfo: NYPLPlatformAPIInfo
 
   /// The timeout to use for all requests to the API endpoint.
   public let requestTimeoutInterval: TimeInterval
@@ -81,10 +80,9 @@ public final class CardCreatorConfiguration: NSObject {
   ///   regular card creation flow.
   ///   - endpointPassword: Password for authenticating on the API used by the
   ///   regular card creation flow.
-  ///   - juvenileParentBarcode: Optional barcode of the parent for creating
-  ///   juvenile accounts.
-  ///   - juvenilePlatformAPIInfo: The platform API endpoints necessary for the
-  ///   juvenile flow. For regular card creation flow, leave this nil.
+  ///   - platformAPIInfo: The platform API endpoints required for card creation.
+  ///   - juvenileParentBarcode: Barcode of the parent for creating
+  ///   juvenile accounts. Required for Juvenile card creation flow.
   ///   - requestTimeoutInterval: Request timeouts for both flows.
   ///   - completionHandler: Completion block that will be called on the main
   ///   thread at the end of both registration flows.
@@ -93,8 +91,8 @@ public final class CardCreatorConfiguration: NSObject {
     endpointVersion: String,
     endpointUsername: String,
     endpointPassword: String,
+    platformAPIInfo: NYPLPlatformAPIInfo,
     juvenileParentBarcode: String = "",
-    juvenilePlatformAPIInfo: NYPLPlatformAPIInfo? = nil,
     requestTimeoutInterval: TimeInterval,
     completionHandler: @escaping (_ username: String, _ PIN: String, _ userInitiated: Bool) -> Void = { _, _, _ in })
   {
@@ -102,10 +100,10 @@ public final class CardCreatorConfiguration: NSObject {
     self.endpointUsername = endpointUsername
     self.endpointPassword = endpointPassword
     self.juvenileParentBarcode = juvenileParentBarcode
-    self.platformAPIInfo = juvenilePlatformAPIInfo
+    self.platformAPIInfo = platformAPIInfo
     self.requestTimeoutInterval = requestTimeoutInterval
     self.completionHandler = completionHandler
-    let isJuvenileFlow = (juvenilePlatformAPIInfo != nil)
+    let isJuvenileFlow = (juvenileParentBarcode.count > 0)
     self.user = UserInfo()
     if isJuvenileFlow {
       self.localizedStrings = JuvenileFlowLocalizedStrings()
@@ -116,7 +114,7 @@ public final class CardCreatorConfiguration: NSObject {
   }
 
   var isJuvenile: Bool {
-    platformAPIInfo != nil
+    juvenileParentBarcode.count > 0
   }
 
   /// Composes the full name of the user being created as it's expected by

--- a/NYPLCardCreator/BusinessLogic/FlowCoordinator+Juvenile.swift
+++ b/NYPLCardCreator/BusinessLogic/FlowCoordinator+Juvenile.swift
@@ -80,7 +80,7 @@ public extension FlowCoordinator {
   ///   - completion: Always called at the end of the calls mentioned above on
   ///   the main queue.
   func checkJuvenileCreationEligibility(parentBarcode: String,
-                                               completion: @escaping (_ error: Error?) -> Void) {
+                                        completion: @escaping (_ error: Error?) -> Void) {
     authenticate(using: configuration.platformAPIInfo) { [weak self] result in
       guard let self = self else {
         return
@@ -134,7 +134,7 @@ public extension FlowCoordinator {
     // contain a valid url. This nil-coalescing check is just for future-proofing.
     let urlStr = req.url?.absoluteString ?? "missing URL from eligibility request"
 
-    let task = self.urlSession.dataTask(with: req) { data, response, error in
+    let task = urlSession.dataTask(with: req) { data, response, error in
       if let error = error {
         completion(error)
         return

--- a/NYPLCardCreator/BusinessLogic/FlowCoordinator.swift
+++ b/NYPLCardCreator/BusinessLogic/FlowCoordinator.swift
@@ -1,0 +1,142 @@
+//
+//  FlowCoordinator.swift
+//  NYPLCardCreator
+//
+//  Created by Ernest Fan on 2021-11-04.
+//  Copyright © 2021 NYPL Labs. All rights reserved.
+//
+
+import UIKit
+
+public class FlowCoordinator {
+  internal let urlSession: URLSession
+  public let configuration: CardCreatorConfiguration
+  internal var authToken: ISSOToken?
+  
+  public init(configuration: CardCreatorConfiguration) {
+    self.configuration = configuration
+    self.urlSession = URLSession(configuration: .ephemeral)
+  }
+  
+  public func startRegularFlow(completion: @escaping (Result<UINavigationController>) -> Void) {    
+    authenticate(using: configuration.platformAPIInfo) { [weak self] result in
+      guard let self = self else {
+        return
+      }
+
+      switch result {
+      case .success(let authToken):
+        self.authToken = authToken
+        let introVC = IntroductionViewController(configuration: self.configuration, authToken: authToken)
+        completion(.success(UINavigationController(rootViewController: introVC)))
+      case .fail(let error):
+        OperationQueue.main.addOperation {
+          completion(.fail(FlowCoordinator.errorWithUserFriendlyMessage(amending: error)))
+        }
+      }
+    }
+  }
+  
+  // MARK: - Fetch ISSOToken
+  
+  func authenticate(using platformEndpoints: NYPLPlatformAPIInfo,
+                    completion: @escaping (Result<ISSOToken>) -> Void) {
+    guard let req = ISSORequest(using: platformEndpoints,
+                                timeoutInterval: configuration.requestTimeoutInterval) else {
+      let err = NSError(domain: ErrorDomain,
+                        code: ErrorCode.jsonEncodingFail.rawValue)
+      completion(.fail(err))
+      return
+    }
+
+    let task = urlSession.dataTask(with: req) { data, response, error in
+      if let error = error {
+        completion(.fail(error))
+        return
+      }
+
+      // note: the request built by ISSORequest(using...) will always contain
+      // a valid url. This nil-coalescing check is just for future-proofing.
+      let urlStrLog = req.url?.absoluteString ?? "missing URL from ISSO auth request"
+
+      guard let data = data else {
+        let err = NSError(domain: ErrorDomain,
+                          code: ErrorCode.noData.rawValue,
+                          userInfo: ["requestURL": urlStrLog])
+        completion(.fail(err))
+        return
+      }
+
+      guard let response = response as? HTTPURLResponse else {
+        let err = NSError(domain: ErrorDomain,
+                          code: ErrorCode.noHTTPResponse.rawValue,
+                          userInfo: ["requestURL": urlStrLog])
+        completion(.fail(err))
+        return
+      }
+
+      guard (200...299).contains(response.statusCode) else {
+        let err = NSError(domain: ErrorDomain,
+                          code: ErrorCode.unsuccessfulHTTPStatusCode.rawValue,
+                          userInfo: ["requestURL": urlStrLog, "response": response])
+        completion(.fail(err))
+        return
+      }
+
+      guard let token = ISSOToken.fromData(data) else {
+        let err = NSError(domain: ErrorDomain,
+                          code: ErrorCode.jsonDecodingFail.rawValue,
+                          userInfo: ["requestURL": urlStrLog, "data": data])
+        completion(.fail(err))
+        return
+      }
+      
+      completion(.success(token))
+    }
+    task.resume()
+  }
+  
+  private func ISSORequest(using platformAPI: NYPLPlatformAPIInfo,
+                           timeoutInterval: TimeInterval) -> URLRequest? {
+    let parameters: [String: String] = [
+      "client_id": platformAPI.clientID,
+      "client_secret": platformAPI.clientSecret,
+      "grant_type": "client_credentials"
+    ]
+
+    let boundary = "Boundary-\(UUID().uuidString)"
+    var body = ""
+    parameters.forEach { (key: String, value: String) in
+      body += "--\(boundary)\r\n"
+      body += "Content-Disposition:form-data; name=\"\(key)\"\r\n"
+      body += "\r\n\(value)\r\n"
+    }
+    body += "--\(boundary)--\r\n";
+    guard let bodyData = body.data(using: .utf8) else {
+      return nil
+    }
+
+    var req = URLRequest(url: platformAPI.oauthTokenURL,
+                         timeoutInterval: timeoutInterval)
+    req.setValue("application/json", forHTTPHeaderField: "Accept")
+    req.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
+    req.httpMethod = "POST"
+    req.httpBody = bodyData
+    return req
+  }
+  
+  // MARK: - Helper
+  
+  internal static func errorWithUserFriendlyMessage(amending error: Error) -> NSError {
+    let nsError = error as NSError
+    if !nsError.localizedDescription.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+      // if we already have a localized description, we're going to trust that
+      return nsError
+    }
+
+    let errorMsg = NSLocalizedString("An error occurred while processing your request.\n\nError Code: \(nsError.code)", comment: "A generic error message for low-level errors")
+    var userInfo = nsError.userInfo
+    userInfo[NSLocalizedDescriptionKey] = errorMsg
+    return NSError(domain: nsError.domain, code: nsError.code, userInfo: userInfo)
+  }
+}

--- a/NYPLCardCreator/BusinessLogic/FlowCoordinator.swift
+++ b/NYPLCardCreator/BusinessLogic/FlowCoordinator.swift
@@ -27,8 +27,10 @@ public class FlowCoordinator {
       switch result {
       case .success(let authToken):
         self.authToken = authToken
-        let introVC = IntroductionViewController(configuration: self.configuration, authToken: authToken)
-        completion(.success(UINavigationController(rootViewController: introVC)))
+        OperationQueue.main.addOperation {
+          let introVC = IntroductionViewController(configuration: self.configuration, authToken: authToken)
+          completion(.success(UINavigationController(rootViewController: introVC)))
+        }
       case .fail(let error):
         OperationQueue.main.addOperation {
           completion(.fail(FlowCoordinator.errorWithUserFriendlyMessage(amending: error)))

--- a/NYPLCardCreator/BusinessLogic/PasswordValidator.swift
+++ b/NYPLCardCreator/BusinessLogic/PasswordValidator.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+class PasswordValidator {
+  /// Below are the rules for the password
+  /// 1. Password must be between 8 - 32 characters
+  /// 2. Password can be a combination of numbers, uppercase / lowercase letters and the following symbols [~ ! ? @ # $ % ^ & * ( )]
+  /// 3. Password cannot consecutively repeat a character 3 or more times, eg. aaa3ka2l
+  /// 4. Password cannot consecutively repeat (2 or more times) a pattern of any 2, 3, or 4-character string. eg. 12341234
+  static func validatePassword(_ password: String) -> Bool {
+    // Rule 1
+    guard password.count >= 8 && password.count <= 32 else {
+      return false
+    }
+    
+    // Rule 2
+    guard password.range(of: #"[^a-zA-Z0-9~!?@#$%^&*()]"#, options: .regularExpression) == nil else {
+      return false
+    }
+    
+    // Rule 3
+    guard password.range(of: #"(.)\1\1"#, options: .regularExpression) == nil else {
+      return false
+    }
+    
+    // Rule 4
+    // "\w" might include underscore but we have already done character check above, so it should be safe
+    guard password.range(of: #"([\w~!?@#$%^&*()]{2,4})\1+"#, options: .regularExpression) == nil else {
+      return false
+    }
+    
+    return true
+  }
+}

--- a/NYPLCardCreator/BusinessLogic/ValidateAddressResponse.swift
+++ b/NYPLCardCreator/BusinessLogic/ValidateAddressResponse.swift
@@ -2,50 +2,38 @@ import Foundation
 
 final class ValidateAddressResponse {  
   enum Response {
-    case validAddress(message: String, address: Address, cardType: CardType)
-    case alternativeAddresses(message: String, addressTuples: [(Address, CardType)])
+    case validAddress(address: Address, cardType: CardType)
+    case alternativeAddresses(message: String?, addresses: [Address])
     case unrecognizedAddress(message: String)
   }
   
   class func responseWithData(_ data: Data) -> Response? {
     guard
       let JSONObject = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: AnyObject],
-      let type = JSONObject["type"] as? String,
-      let message = JSONObject["message"] as? String
+      let type = JSONObject["type"] as? String
       else { return nil }
-    
     switch type {
     case "valid-address":
+      // The v0.3 API does not return a card type value, keeping this for future proof
       var cardType = CardType.none
-      if JSONObject["card_type"] as? String == "temporary" {
-        cardType = .temporary
-      } else if JSONObject["card_type"] as? String == "standard" {
-        cardType = .standard
+      if let cardTypeString = JSONObject["cardType"] as? String,
+         let newValue = CardType.init(rawValue: cardTypeString) {
+        cardType = newValue
       }
       guard
         let addressObject = JSONObject["address"],
         let address = Address.addressWithJSONObject(addressObject)
         else { return nil }
-      return Response.validAddress(message: message, address: address, cardType: cardType)
+      return Response.validAddress(address: address, cardType: cardType)
     case "alternate-addresses":
-      guard let addressContainingObjects = JSONObject["addresses"] as? [AnyObject] else { return nil }
-      let addressTuples = addressContainingObjects.compactMap({(object: AnyObject) -> (Address, CardType)? in
-        guard
-          let JSONObject = object as? [String: AnyObject],
-          let addressJSON = JSONObject["address"] as? [String: AnyObject],
-          let address = Address.addressWithJSONObject(addressJSON)
-          else { return nil }
-        let cardTypeString = JSONObject["card_type"] as? String
-        var cardType = CardType.none
-        if cardTypeString == "temporary" {
-          cardType = .temporary
-        } else if cardTypeString == "standard" {
-          cardType = .standard
-        }
-        return (address, cardType)
-      })
-      return Response.alternativeAddresses(message: message, addressTuples: addressTuples)
+      guard let addressObjects = JSONObject["addresses"] as? [[String: AnyObject]] else {
+        return nil
+      }
+      let message = JSONObject["message"] as? String
+      let addresses = addressObjects.compactMap { Address.addressWithJSONObject($0) }
+      return Response.alternativeAddresses(message: message, addresses: addresses)
     case "unrecognized-address":
+      guard let message = JSONObject["message"] as? String else { return nil }
       return Response.unrecognizedAddress(message: message)
     default:
       break

--- a/NYPLCardCreator/Flow/AddressViewController.swift
+++ b/NYPLCardCreator/Flow/AddressViewController.swift
@@ -265,7 +265,18 @@ final class AddressViewController: FormTableViewController {
       return nil
     }
     
-    return Address(street1: street1, street2: self.street2Cell.textField.text, city: city, region: region, zip: zip)
+    let isResidential: Bool = {
+      switch self.addressStep {
+      case .home:
+        return true
+      case .school:
+        fallthrough
+      case .work:
+        return false
+      }
+    }()
+    
+    return Address(street1: street1, street2: self.street2Cell.textField.text, city: city, region: region, zip: zip, isResidential: isResidential, hasBeenValidated: false)
   }
   
   fileprivate func submit() {
@@ -275,24 +286,16 @@ final class AddressViewController: FormTableViewController {
         NSLocalizedString(
           "Validating Address",
           comment: "A title telling the user their address is currently being validated"))
-    var request = URLRequest.init(url: self.configuration.endpointURL.appendingPathComponent("validate/address"))
-    let isSchoolOrWorkAddress: Bool = {
-      switch self.addressStep {
-      case .home:
-        return false
-      case .school:
-        return true
-      case .work:
-        return true
-      }
-    }()
+    var request = URLRequest.init(url: self.configuration.endpointURL.appendingPathComponent("validations/address"))
+    
     let JSONObject: [String: AnyObject] = [
-      "address": self.currentAddress()!.JSONObject() as AnyObject,
-      "is_work_or_school_address": isSchoolOrWorkAddress as AnyObject
+      "address": self.currentAddress()!.JSONObject() as AnyObject
     ]
     request.httpBody = try! JSONSerialization.data(withJSONObject: JSONObject, options: [.prettyPrinted])
     request.httpMethod = "POST"
-    request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    request.setValue("application/json", forHTTPHeaderField: "Accept")
+    request.setValue("\(authToken.tokenType) \(authToken.accessToken)", forHTTPHeaderField: "Authorization")
     request.timeoutInterval = self.configuration.requestTimeoutInterval
     let task = self.session.dataTaskWithRequest(request) { (data, response, error) in
       OperationQueue.main.addOperation {
@@ -323,7 +326,11 @@ final class AddressViewController: FormTableViewController {
             handler: nil))
           self.present(alertController, animated: true, completion: nil)
         }
-        if (response as! HTTPURLResponse).statusCode != 200 || data == nil {
+        // While responses with status code 400 are mostly errors, we need to handle the error
+        // on a case by case basis (eg. alternate addresses) in the ValidateAddressResponse class
+        if (response as! HTTPURLResponse).statusCode != 200 &&
+            (response as! HTTPURLResponse).statusCode != 400 ||
+            data == nil {
           showErrorAlert()
           return
         }
@@ -332,19 +339,26 @@ final class AddressViewController: FormTableViewController {
           return
         }
         switch validateAddressResponse {
-        case let .validAddress(_, address, cardType):
+        case let .validAddress(address, cardType):
+            // The v0.3 API does not return CardType value,
+            // therefore we set the CardType to standard if the address is within NY.
+            let newCardType = self.validateCardType(for: address, cardType: cardType)
             let viewController = ConfirmValidAddressViewController(
                 configuration: self.configuration,
                 authToken: self.authToken,
                 addressStep: self.addressStep,
-                validAddressAndCardType: (address, cardType))
+                validAddressAndCardType: (address, newCardType))
             self.navigationController?.pushViewController(viewController, animated: true)
-        case let .alternativeAddresses(_, addressTuples):
+        case let .alternativeAddresses(_, addresses):
+          let addressesAndCardTypes: [(Address, CardType)] = addresses.map {
+            let cardType: CardType = self.validateCardType(for: $0)
+            return ($0, cardType)
+          }
           let viewController = AlternativeAddressesViewController(
             configuration: self.configuration,
             authToken: self.authToken,
             addressStep: self.addressStep,
-            alternativeAddressesAndCardTypes: addressTuples)
+            alternativeAddressesAndCardTypes: addressesAndCardTypes)
           self.navigationController?.pushViewController(viewController, animated: true)
         case .unrecognizedAddress:
           let alertController = UIAlertController(
@@ -365,5 +379,17 @@ final class AddressViewController: FormTableViewController {
     }
     
     task.resume()
+  }
+  
+  // MARK: - Helper
+  
+  /// If we do not receive a CardType value from server, we will return a CardType based on address's region
+  private func validateCardType(for address: Address, cardType: CardType = .none) -> CardType {
+    // Received CardType from server, no action needed
+    if cardType != .none {
+      return cardType
+    }
+    
+    return address.region.lowercased() == "ny" ? .standard : .none
   }
 }

--- a/NYPLCardCreator/Flow/AddressViewController.swift
+++ b/NYPLCardCreator/Flow/AddressViewController.swift
@@ -4,6 +4,7 @@ import UIKit
 final class AddressViewController: FormTableViewController {
   
   fileprivate let configuration: CardCreatorConfiguration
+  fileprivate let authToken: ISSOToken
   
   fileprivate let addressStep: AddressStep
   fileprivate let street1Cell: LabelledTextViewCell
@@ -14,8 +15,12 @@ final class AddressViewController: FormTableViewController {
   
   fileprivate let session: AuthenticatingSession
   
-  init(configuration: CardCreatorConfiguration, addressStep: AddressStep) {
+  init(configuration: CardCreatorConfiguration,
+       authToken: ISSOToken,
+       addressStep: AddressStep)
+  {
     self.configuration = configuration
+    self.authToken = authToken
     self.addressStep = addressStep
     self.street1Cell = LabelledTextViewCell(
       title: NSLocalizedString("Street 1", comment: "The first line of a US street address"),
@@ -330,12 +335,14 @@ final class AddressViewController: FormTableViewController {
         case let .validAddress(_, address, cardType):
             let viewController = ConfirmValidAddressViewController(
                 configuration: self.configuration,
+                authToken: self.authToken,
                 addressStep: self.addressStep,
                 validAddressAndCardType: (address, cardType))
             self.navigationController?.pushViewController(viewController, animated: true)
         case let .alternativeAddresses(_, addressTuples):
           let viewController = AlternativeAddressesViewController(
             configuration: self.configuration,
+            authToken: self.authToken,
             addressStep: self.addressStep,
             alternativeAddressesAndCardTypes: addressTuples)
           self.navigationController?.pushViewController(viewController, animated: true)

--- a/NYPLCardCreator/Flow/AlternativeAddressesViewController.swift
+++ b/NYPLCardCreator/Flow/AlternativeAddressesViewController.swift
@@ -80,12 +80,12 @@ final class AlternativeAddressesViewController: TableViewController {
   }
   
   // MARK: UITableViewDelegate
-  
-  func tableView(_ tableView: UITableView, didSelectRowAtIndexPath indexPath: IndexPath) {
+  func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+    tableView.deselectRow(at: indexPath, animated: false)
     let (address, cardType) = self.alternativeAddressesAndCardTypes[indexPath.row]
     self.addressStep.continueFlowWithValidAddress(
       self.configuration,
-      authToken: authToken,
+      authToken: self.authToken,
       viewController: self,
       address: address,
       cardType: cardType)

--- a/NYPLCardCreator/Flow/AlternativeAddressesViewController.swift
+++ b/NYPLCardCreator/Flow/AlternativeAddressesViewController.swift
@@ -8,15 +8,18 @@ final class AlternativeAddressesViewController: TableViewController {
   fileprivate let headerLabel: UILabel
   
   fileprivate let configuration: CardCreatorConfiguration
+  fileprivate let authToken: ISSOToken
   
   fileprivate static let addressCellReuseIdentifier = "addressCellReuseIdentifier"
   
   init(
     configuration: CardCreatorConfiguration,
+    authToken: ISSOToken,
     addressStep: AddressStep,
     alternativeAddressesAndCardTypes: [(Address, CardType)])
   {
     self.configuration = configuration
+    self.authToken = authToken
     self.addressStep = addressStep
     self.alternativeAddressesAndCardTypes = alternativeAddressesAndCardTypes
     
@@ -82,6 +85,7 @@ final class AlternativeAddressesViewController: TableViewController {
     let (address, cardType) = self.alternativeAddressesAndCardTypes[indexPath.row]
     self.addressStep.continueFlowWithValidAddress(
       self.configuration,
+      authToken: authToken,
       viewController: self,
       address: address,
       cardType: cardType)

--- a/NYPLCardCreator/Flow/CardCreator.swift
+++ b/NYPLCardCreator/Flow/CardCreator.swift
@@ -1,9 +1,0 @@
-import UIKit
-
-@objcMembers public final class CardCreator: NSObject {
-  public static func initialNavigationController(
-    configuration: CardCreatorConfiguration) -> UINavigationController
-  {
-    return UINavigationController(rootViewController: IntroductionViewController(configuration: configuration))
-  }
-}

--- a/NYPLCardCreator/Flow/ConfirmValidAddressViewController.swift
+++ b/NYPLCardCreator/Flow/ConfirmValidAddressViewController.swift
@@ -7,6 +7,7 @@ final class ConfirmValidAddressViewController: TableViewController {
   fileprivate let validAddressAndCardType: (Address, CardType)
   
   fileprivate let configuration: CardCreatorConfiguration
+  fileprivate let authToken: ISSOToken
   
   fileprivate let headerLabel: UILabel
   
@@ -14,10 +15,12 @@ final class ConfirmValidAddressViewController: TableViewController {
   
   init(
     configuration: CardCreatorConfiguration,
+    authToken: ISSOToken,
     addressStep: AddressStep,
     validAddressAndCardType: (Address, CardType))
   {
     self.configuration = configuration
+    self.authToken = authToken
     self.addressStep = addressStep
     self.validAddressAndCardType = validAddressAndCardType
     
@@ -111,6 +114,7 @@ final class ConfirmValidAddressViewController: TableViewController {
     let (address, cardType) = self.validAddressAndCardType
     self.addressStep.continueFlowWithValidAddress(
       self.configuration,
+      authToken: authToken,
       viewController: self,
       address: address,
       cardType: cardType)

--- a/NYPLCardCreator/Flow/IntroductionViewController.swift
+++ b/NYPLCardCreator/Flow/IntroductionViewController.swift
@@ -10,12 +10,16 @@ final class IntroductionViewController: UIViewController, UITableViewDelegate, U
   private var attestationVerified: Bool
   private var eulaVerified: Bool
   private var tableView: UITableView!
+  private let authToken: ISSOToken
 
-  public init(configuration: CardCreatorConfiguration) {
+  public init(configuration: CardCreatorConfiguration,
+              authToken: ISSOToken)
+  {
     self.configuration = configuration
     self.descriptionLabel = UILabel()
     self.attestationVerified = false
     self.eulaVerified = false
+    self.authToken = authToken
     super.init(nibName: nil, bundle: nil)
   }
   
@@ -240,7 +244,7 @@ final class IntroductionViewController: UIViewController, UITableViewDelegate, U
   @objc private func didSelectNext() {
     if (attestationVerified && eulaVerified) {
       self.navigationController?.pushViewController(
-      LocationViewController(configuration: self.configuration),
+      LocationViewController(configuration: self.configuration, authToken: authToken),
       animated: true)
     } else if (!attestationVerified && eulaVerified) {
       attestationAlert()

--- a/NYPLCardCreator/Flow/LocationViewController.swift
+++ b/NYPLCardCreator/Flow/LocationViewController.swift
@@ -10,9 +10,13 @@ final class LocationViewController: UIViewController {
   private let resultLabel = UILabel()
   private var placemarkQuery: PlacemarkQuery? = nil
   private var viewDidAppearPreviously: Bool = false
+  private let authToken: ISSOToken
 
-  init(configuration: CardCreatorConfiguration) {
+  init(configuration: CardCreatorConfiguration,
+       authToken: ISSOToken)
+  {
     self.configuration = configuration
+    self.authToken = authToken
     super.init(nibName: nil, bundle: nil)
   }
   
@@ -87,9 +91,10 @@ final class LocationViewController: UIViewController {
   @objc private func didSelectNext() {
     let vc: UIViewController
     if configuration.isJuvenile {
-      vc = NameAndEmailViewController(juvenileConfiguration: configuration)
+      vc = NameAndEmailViewController(juvenileConfiguration: configuration, authToken: authToken)
     } else {
       vc = AddressViewController(configuration: self.configuration,
+                                 authToken: authToken,
                                  addressStep: .home)
     }
 

--- a/NYPLCardCreator/Flow/NameAndEmailViewController.swift
+++ b/NYPLCardCreator/Flow/NameAndEmailViewController.swift
@@ -20,7 +20,7 @@ final class NameAndEmailViewController: FormTableViewController {
     // juvenile flows
     self.init(configuration: juvenileConfiguration,
               authToken: authToken,
-              homeAddress: Address(street1: "", street2: "", city: "", region: "", zip: ""),
+              homeAddress: Address(street1: "", street2: "", city: "", region: "", zip: "", isResidential: false, hasBeenValidated: false),
               schoolOrWorkAddress: nil,
               cardType: .juvenile)
   }

--- a/NYPLCardCreator/Flow/NameAndEmailViewController.swift
+++ b/NYPLCardCreator/Flow/NameAndEmailViewController.swift
@@ -3,6 +3,7 @@ import UIKit
 final class NameAndEmailViewController: FormTableViewController {
   
   private let configuration: CardCreatorConfiguration
+  private let authToken: ISSOToken
   
   private let cardType: CardType
   private let firstNameCell: LabelledTextViewCell
@@ -12,20 +13,25 @@ final class NameAndEmailViewController: FormTableViewController {
   private let homeAddress: Address
   private let schoolOrWorkAddress: Address?
 
-  convenience init(juvenileConfiguration: CardCreatorConfiguration) {
+  convenience init(juvenileConfiguration: CardCreatorConfiguration,
+                   authToken: ISSOToken)
+  {
     // providing a fake home address because it will be ignored anyway for
     // juvenile flows
     self.init(configuration: juvenileConfiguration,
+              authToken: authToken,
               homeAddress: Address(street1: "", street2: "", city: "", region: "", zip: ""),
               schoolOrWorkAddress: nil,
               cardType: .juvenile)
   }
 
   init(configuration: CardCreatorConfiguration,
+       authToken: ISSOToken,
        homeAddress: Address,
        schoolOrWorkAddress: Address?,
        cardType: CardType) {
     self.configuration = configuration
+    self.authToken = authToken
 
     let requiredPlaceholder = NSLocalizedString("Required", comment: "A placeholder for a required text field")
     let optionalPlaceholder = NSLocalizedString("Optional", comment: "A placeholder for a required text field")
@@ -152,6 +158,7 @@ final class NameAndEmailViewController: FormTableViewController {
     self.navigationController?.pushViewController(
       UsernameAndPINViewController(
         configuration: self.configuration,
+        authToken: authToken,
         homeAddress: self.homeAddress,
         schoolOrWorkAddress: self.schoolOrWorkAddress,
         cardType: self.cardType,

--- a/NYPLCardCreator/Flow/UserSummaryViewController.swift
+++ b/NYPLCardCreator/Flow/UserSummaryViewController.swift
@@ -14,6 +14,7 @@ final class UserSummaryViewController: TableViewController, JuvenileCardCreation
   private let headerLabel: UILabel
   
   private let configuration: CardCreatorConfiguration
+  private let authToken: ISSOToken
   private let session: AuthenticatingSession
   
   private let homeAddressCell: SummaryAddressCell
@@ -33,6 +34,7 @@ final class UserSummaryViewController: TableViewController, JuvenileCardCreation
 
   init(
     configuration: CardCreatorConfiguration,
+    authToken: ISSOToken,
     homeAddress: Address,
     schoolOrWorkAddress: Address?,
     cardType: CardType,
@@ -42,6 +44,7 @@ final class UserSummaryViewController: TableViewController, JuvenileCardCreation
     pin: String)
   {
     self.configuration = configuration
+    self.authToken = authToken
     self.session = AuthenticatingSession(configuration: configuration)
 
     self.homeAddress = homeAddress

--- a/NYPLCardCreator/Flow/UsernameAndPINViewController.swift
+++ b/NYPLCardCreator/Flow/UsernameAndPINViewController.swift
@@ -4,6 +4,7 @@ import UIKit
 final class UsernameAndPINViewController: FormTableViewController {
   
   private let configuration: CardCreatorConfiguration
+  private let authToken: ISSOToken
   
   private let usernameCell: LabelledTextViewCell
   private let pinCell: LabelledTextViewCell
@@ -17,6 +18,7 @@ final class UsernameAndPINViewController: FormTableViewController {
   
   init(
     configuration: CardCreatorConfiguration,
+    authToken: ISSOToken,
     homeAddress: Address,
     schoolOrWorkAddress: Address?,
     cardType: CardType,
@@ -24,6 +26,7 @@ final class UsernameAndPINViewController: FormTableViewController {
     email: String)
   {
     self.configuration = configuration
+    self.authToken = authToken
     self.usernameCell = LabelledTextViewCell(
       title: NSLocalizedString("Username", comment: "A username used to log into a service"),
       placeholder: NSLocalizedString("Required", comment: "A placeholder for a required text field"))
@@ -217,6 +220,7 @@ final class UsernameAndPINViewController: FormTableViewController {
     self.navigationController?.pushViewController(
       UserSummaryViewController(
         configuration: self.configuration,
+        authToken: self.authToken,
         homeAddress: self.homeAddress,
         schoolOrWorkAddress: self.schoolOrWorkAddress,
         cardType: self.cardType,

--- a/NYPLCardCreator/Helpers/Address.swift
+++ b/NYPLCardCreator/Helpers/Address.swift
@@ -6,13 +6,15 @@ struct Address {
   let city: String
   let region: String
   let zip: String
+  let isResidential: Bool
+  let hasBeenValidated: Bool
   
   /// Takes a JSON object of the form retured from the server (where "state" is mapped
   /// to the `region` property).
   static func addressWithJSONObject(_ object: Any) -> Address? {
     guard
       let address = object as? [String: AnyObject],
-      let street1 = address["line_1"] as? String,
+      let street1 = address["line1"] as? String,
       let city = address["city"] as? String,
       let region = address["state"] as? String,
       let zip = address["zip"] as? String
@@ -21,17 +23,22 @@ struct Address {
       return nil
     }
     
-    return Address(street1: street1, street2: address["line_2"] as? String, city: city, region: region, zip: zip)
+    let isResidential = address["isResidential"] as? Bool ?? false
+    let hasBeenValidated = address["hasBeenValidated"] as? Bool ?? false
+    
+    return Address(street1: street1, street2: address["line2"] as? String, city: city, region: region, zip: zip, isResidential: isResidential, hasBeenValidated: hasBeenValidated)
   }
   
   /// Returns a JSON object of the form required by the server.
   func JSONObject() -> [String: String] {
     return [
-      "line_1": self.street1,
-      "line_2": self.street2 == nil ? "" : self.street2!,
+      "line1": self.street1,
+      "line2": self.street2 == nil ? "" : self.street2!,
       "city": self.city,
       "state": self.region,
-      "zip": self.zip
+      "zip": self.zip,
+      "isResidential": String(self.isResidential),
+      "hasBeenValidated": String(self.hasBeenValidated)
     ]
   }
 }

--- a/NYPLCardCreator/Helpers/CardType.swift
+++ b/NYPLCardCreator/Helpers/CardType.swift
@@ -2,7 +2,7 @@
 ///
 /// The exact implications of a particular card type on the registration flow are
 /// somewhat subtle. Consult the API documentation for more information.
-enum CardType {
+enum CardType: String {
   case none
   case temporary
   case standard

--- a/NYPLCardCreatorExample/AppDelegate.swift
+++ b/NYPLCardCreatorExample/AppDelegate.swift
@@ -17,11 +17,21 @@ class AppDelegate: UIResponder, UIApplicationDelegate
     self.window?.tintAdjustmentMode = .normal;
     self.window?.makeKeyAndVisible()
     
+    let platformAPIInfo = NYPLPlatformAPIInfo(
+      oauthTokenURL: URL(string: "https://example.com/token")!,
+      clientID: "clientID",
+      clientSecret: "secret",
+      baseURL: URL(string: "https://example.com")!)!
+    
+    // This testapp does not work with the v0.3 API
+    // because the clientID and clientSecret are only accessible from SimplyE,
+    // and there are no test ID and secret.
     let configuration = CardCreatorConfiguration(
-      endpointURL: URL(string: "http://qa.patrons.librarysimplified.org/")!,
+      endpointURL: URL(string: "https://platform.nypl.org/api/v0.3/")!,
       endpointVersion: "v1",
       endpointUsername: "test_key",
       endpointPassword: "test_secret",
+      platformAPIInfo: platformAPIInfo,
       requestTimeoutInterval: 20.0)
     { (username, PIN, initiated) in
         self.window?.rootViewController?.dismiss(animated: true, completion: nil)
@@ -36,11 +46,20 @@ class AppDelegate: UIResponder, UIApplicationDelegate
         self.window?.rootViewController?.present(alertController, animated: true, completion: nil)
     }
     
-    let initialViewController = CardCreator.initialNavigationController(configuration: configuration)
-    
-    DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + Double(Int64(NSEC_PER_SEC)) / Double(NSEC_PER_SEC)) {
-      initialViewController.modalPresentationStyle = .formSheet
-      self.window?.rootViewController?.present(initialViewController, animated: true, completion: nil)
+    let flowCoordinator = FlowCoordinator.init(configuration: configuration)
+    flowCoordinator.startRegularFlow { result in
+      var viewController: UIViewController
+      switch result {
+      case .fail(let error):
+        viewController = UIAlertController(title: "Failed to initialize Card Creation", message: error.localizedDescription, preferredStyle: .alert)
+      case .success(let initialController):
+        viewController = initialController
+        viewController.modalPresentationStyle = .formSheet
+      }
+      
+      DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + Double(Int64(NSEC_PER_SEC)) / Double(NSEC_PER_SEC)) {
+        self.window?.rootViewController?.present(viewController, animated: true, completion: nil)
+      }
     }
     
     return true

--- a/NYPLCardCreatorTests/CardCreatorConfigurationTests.swift
+++ b/NYPLCardCreatorTests/CardCreatorConfigurationTests.swift
@@ -17,12 +17,12 @@ class CardCreatorConfigurationTests: XCTestCase {
       endpointVersion: "1",
       endpointUsername: "test",
       endpointPassword: "password",
-      juvenileParentBarcode: "parent",
-      juvenilePlatformAPIInfo: NYPLPlatformAPIInfo(
+      platformAPIInfo: NYPLPlatformAPIInfo(
         oauthTokenURL: URL(string: "https://example.com/token")!,
         clientID: "clientID",
         clientSecret: "secret",
-        baseURL: URL(string: "https://example.com")!),
+        baseURL: URL(string: "https://example.com")!)!,
+      juvenileParentBarcode: "parent",
       requestTimeoutInterval: 1.0)
     XCTAssert(juvenileConfig.isJuvenile)
 
@@ -52,6 +52,11 @@ class CardCreatorConfigurationTests: XCTestCase {
       endpointVersion: "1",
       endpointUsername: "test",
       endpointPassword: "password",
+      platformAPIInfo: NYPLPlatformAPIInfo(
+        oauthTokenURL: URL(string: "https://example.com/token")!,
+        clientID: "clientID",
+        clientSecret: "secret",
+        baseURL: URL(string: "https://example.com")!)!,
       requestTimeoutInterval: 1.0)
     XCTAssertFalse(config.isJuvenile)
 

--- a/NYPLCardCreatorTests/PasswordValidationTests.swift
+++ b/NYPLCardCreatorTests/PasswordValidationTests.swift
@@ -1,0 +1,55 @@
+import XCTest
+@testable import NYPLCardCreator
+
+class PasswordValidationTests: XCTestCase {
+  func testPasswordCharacterCount() throws {
+    XCTAssertFalse(PasswordValidator.validatePassword("1234567"))
+    
+    XCTAssertTrue(PasswordValidator.validatePassword("12345678"))
+    
+    let stringWithMaxCharacters = "abcdefghijklmnopqrstuvwxyz123456"
+    XCTAssertTrue(PasswordValidator.validatePassword(stringWithMaxCharacters))
+    
+    XCTAssertFalse(PasswordValidator.validatePassword(stringWithMaxCharacters + "a"))
+  }
+  
+  func testSymbols() throws {
+    let validSymbolString = #"~!?@#$%^&*()"#
+    XCTAssertTrue(PasswordValidator.validatePassword(validSymbolString))
+    
+    XCTAssertFalse(PasswordValidator.validatePassword("asdfg_<"))
+    XCTAssertFalse(PasswordValidator.validatePassword("asdfg_>"))
+    XCTAssertFalse(PasswordValidator.validatePassword(#"asdfg_\"#))
+    XCTAssertFalse(PasswordValidator.validatePassword("asdfg_/"))
+    XCTAssertFalse(PasswordValidator.validatePassword("asdfg_."))
+    XCTAssertFalse(PasswordValidator.validatePassword("asdfg_ "))
+  }
+
+  func testRepeatingCharacters() throws {
+    XCTAssertTrue(PasswordValidator.validatePassword("aabbccddeeffgg"))
+    
+    XCTAssertFalse(PasswordValidator.validatePassword("1234444asd"))
+    XCTAssertFalse(PasswordValidator.validatePassword("111asbciwhnk@#$"))
+    XCTAssertFalse(PasswordValidator.validatePassword("123aaa567"))
+    XCTAssertFalse(PasswordValidator.validatePassword("abcdefg00000000000000"))
+    XCTAssertFalse(PasswordValidator.validatePassword("aolghe$$$$$"))
+    XCTAssertFalse(PasswordValidator.validatePassword("123@@@mcns"))
+  }
+  
+  func testRepeatingPatterns() throws {
+    XCTAssertTrue(PasswordValidator.validatePassword("aa4567aa"))
+    XCTAssertTrue(PasswordValidator.validatePassword("abc12abc"))
+    XCTAssertTrue(PasswordValidator.validatePassword("aabb234bbaa"))
+    XCTAssertTrue(PasswordValidator.validatePassword("1234512345"))
+    XCTAssertTrue(PasswordValidator.validatePassword("~~aa~~AA"))
+    XCTAssertTrue(PasswordValidator.validatePassword("~~aa~~AA~~aa"))
+    
+    XCTAssertFalse(PasswordValidator.validatePassword("ab1212ab"))
+    XCTAssertFalse(PasswordValidator.validatePassword("12124545"))
+    XCTAssertFalse(PasswordValidator.validatePassword("abcabc12"))
+    XCTAssertFalse(PasswordValidator.validatePassword("~!@~!@~!@~!@~!@"))
+    XCTAssertFalse(PasswordValidator.validatePassword("abcdabcd"))
+    XCTAssertFalse(PasswordValidator.validatePassword("~~aa~~aa"))
+    XCTAssertFalse(PasswordValidator.validatePassword("~~aa~~AA~~aa~~aa"))
+  }
+}


### PR DESCRIPTION
**What's this do?**
Implement password validation (still need work on UI and API)
Implement auth token for new API
Switch to new API for address validation

**Why are we doing this? (w/ JIRA link if applicable)**
[ios-232](https://jira.nypl.org/browse/IOS-232)
In order to submit the alphanumeric password to server-side, we need to switch to the new [API](https://github.com/NYPL/dgx-patron-creator-service/wiki/API-V0.3)

**How should this be tested? / Do these changes have associated tests?**
Not ready to be tested

**Dependencies for merging? Releasing to production?**
N/A

**Does this include changes that require a new SimplyE/Open eBooks build for QA?**
N/A

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@ErnestFan tested with SE
