### PR TITLE
iOS-232 Update API request for username validation and patron creation

### DIFF
--- a/NYPLCardCreator.xcodeproj/project.pbxproj
+++ b/NYPLCardCreator.xcodeproj/project.pbxproj
@@ -28,7 +28,7 @@
 		14E61C7920DD7C6200124E2B /* AddressViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 146E47C720DD746300C8F97F /* AddressViewController.swift */; };
 		14E61C7A20DD7C6200124E2B /* AuthenticatingSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 146E47B220DD746300C8F97F /* AuthenticatingSession.swift */; };
 		14E61C7B20DD7C6200124E2B /* AddressStep.swift in Sources */ = {isa = PBXBuildFile; fileRef = 146E47B520DD746300C8F97F /* AddressStep.swift */; };
-		14E61C7C20DD7C6200124E2B /* NameAndEmailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 146E47C920DD746300C8F97F /* NameAndEmailViewController.swift */; };
+		14E61C7C20DD7C6200124E2B /* UserPersonalInfoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 146E47C920DD746300C8F97F /* UserPersonalInfoViewController.swift */; };
 		14E61C7D20DD7C6200124E2B /* AlternativeAddressesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 146E47C220DD746300C8F97F /* AlternativeAddressesViewController.swift */; };
 		14E61C7E20DD7C6200124E2B /* CardCreatorConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 146E47BA20DD746300C8F97F /* CardCreatorConfiguration.swift */; };
 		14E61C7F20DD7C6200124E2B /* UsernameAndPasswordViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 146E47BC20DD746300C8F97F /* UsernameAndPasswordViewController.swift */; };
@@ -44,6 +44,7 @@
 		176F5BCE2644D28D002CBA0E /* PureLayout.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 176F5BCD2644D28D002CBA0E /* PureLayout.xcframework */; };
 		176F5BCF2644D28D002CBA0E /* PureLayout.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 176F5BCD2644D28D002CBA0E /* PureLayout.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		179267E92734D85D004EA5E7 /* FlowCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 179267E82734D85D004EA5E7 /* FlowCoordinator.swift */; };
+		1792694F2743332C004EA5E7 /* PatronCreationInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1792694E2743332B004EA5E7 /* PatronCreationInfo.swift */; };
 		17B17A96272B9F5400314AF6 /* PasswordValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17B17A95272B9F5400314AF6 /* PasswordValidator.swift */; };
 		17B17A9A272BAE2000314AF6 /* PasswordValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17B17A99272BAE2000314AF6 /* PasswordValidationTests.swift */; };
 		2D6F7C391D90FB3A000B906A /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 2D6F7C381D90FB3A000B906A /* InfoPlist.strings */; };
@@ -125,7 +126,7 @@
 		146E47C620DD746300C8F97F /* ValidateAddressResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValidateAddressResponse.swift; sourceTree = "<group>"; };
 		146E47C720DD746300C8F97F /* AddressViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressViewController.swift; sourceTree = "<group>"; };
 		146E47C820DD746300C8F97F /* SummaryAddressCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryAddressCell.swift; sourceTree = "<group>"; };
-		146E47C920DD746300C8F97F /* NameAndEmailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NameAndEmailViewController.swift; sourceTree = "<group>"; };
+		146E47C920DD746300C8F97F /* UserPersonalInfoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserPersonalInfoViewController.swift; sourceTree = "<group>"; };
 		14E61C5C20DD7C4800124E2B /* NYPLCardCreator.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = NYPLCardCreator.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		14E61C5E20DD7C4800124E2B /* NYPLCardCreator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NYPLCardCreator.h; sourceTree = "<group>"; };
 		14E61C5F20DD7C4800124E2B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -134,6 +135,7 @@
 		1754097226FE7FD900B8E077 /* NYPLColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLColor.swift; sourceTree = "<group>"; };
 		176F5BCD2644D28D002CBA0E /* PureLayout.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = PureLayout.xcframework; path = Carthage/Build/PureLayout.xcframework; sourceTree = "<group>"; };
 		179267E82734D85D004EA5E7 /* FlowCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlowCoordinator.swift; sourceTree = "<group>"; };
+		1792694E2743332B004EA5E7 /* PatronCreationInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PatronCreationInfo.swift; sourceTree = "<group>"; };
 		17B17A95272B9F5400314AF6 /* PasswordValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordValidator.swift; sourceTree = "<group>"; };
 		17B17A99272BAE2000314AF6 /* PasswordValidationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordValidationTests.swift; sourceTree = "<group>"; };
 		2D6F7C381D90FB3A000B906A /* InfoPlist.strings */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = InfoPlist.strings; path = ../NYPLCardCreatorExample/InfoPlist.strings; sourceTree = "<group>"; };
@@ -246,7 +248,7 @@
 				146E47C720DD746300C8F97F /* AddressViewController.swift */,
 				146E47C420DD746300C8F97F /* ConfirmValidAddressViewController.swift */,
 				146E47C220DD746300C8F97F /* AlternativeAddressesViewController.swift */,
-				146E47C920DD746300C8F97F /* NameAndEmailViewController.swift */,
+				146E47C920DD746300C8F97F /* UserPersonalInfoViewController.swift */,
 				146E47BC20DD746300C8F97F /* UsernameAndPasswordViewController.swift */,
 				146E47C320DD746300C8F97F /* UserSummaryViewController.swift */,
 				146E47C520DD746300C8F97F /* UserCredentialsViewController.swift */,
@@ -284,6 +286,7 @@
 				146E47C620DD746300C8F97F /* ValidateAddressResponse.swift */,
 				146E47B820DD746300C8F97F /* ValidateUsernameResponse.swift */,
 				17B17A95272B9F5400314AF6 /* PasswordValidator.swift */,
+				1792694E2743332B004EA5E7 /* PatronCreationInfo.swift */,
 			);
 			path = BusinessLogic;
 			sourceTree = "<group>";
@@ -479,7 +482,7 @@
 				17B17A96272B9F5400314AF6 /* PasswordValidator.swift in Sources */,
 				14E61C7320DD7C6200124E2B /* FormTableViewController.swift in Sources */,
 				1754097326FE7FD900B8E077 /* NYPLColor.swift in Sources */,
-				14E61C7C20DD7C6200124E2B /* NameAndEmailViewController.swift in Sources */,
+				14E61C7C20DD7C6200124E2B /* UserPersonalInfoViewController.swift in Sources */,
 				179267E92734D85D004EA5E7 /* FlowCoordinator.swift in Sources */,
 				14E61C7420DD7C6200124E2B /* PlacemarkQuery.swift in Sources */,
 				73935214246CD0C200ACC0AB /* FlowCoordinator+Juvenile.swift in Sources */,
@@ -490,6 +493,7 @@
 				14E61C7E20DD7C6200124E2B /* CardCreatorConfiguration.swift in Sources */,
 				7353354D246DBB8D000C2874 /* ResultErrors.swift in Sources */,
 				14E61C6E20DD7C6200124E2B /* ValidateUsernameResponse.swift in Sources */,
+				1792694F2743332C004EA5E7 /* PatronCreationInfo.swift in Sources */,
 				14E61C7B20DD7C6200124E2B /* AddressStep.swift in Sources */,
 				14E61C6920DD7C6200124E2B /* Address.swift in Sources */,
 				14E61C7D20DD7C6200124E2B /* AlternativeAddressesViewController.swift in Sources */,

--- a/NYPLCardCreator.xcodeproj/project.pbxproj
+++ b/NYPLCardCreator.xcodeproj/project.pbxproj
@@ -31,7 +31,7 @@
 		14E61C7C20DD7C6200124E2B /* NameAndEmailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 146E47C920DD746300C8F97F /* NameAndEmailViewController.swift */; };
 		14E61C7D20DD7C6200124E2B /* AlternativeAddressesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 146E47C220DD746300C8F97F /* AlternativeAddressesViewController.swift */; };
 		14E61C7E20DD7C6200124E2B /* CardCreatorConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 146E47BA20DD746300C8F97F /* CardCreatorConfiguration.swift */; };
-		14E61C7F20DD7C6200124E2B /* UsernameAndPINViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 146E47BC20DD746300C8F97F /* UsernameAndPINViewController.swift */; };
+		14E61C7F20DD7C6200124E2B /* UsernameAndPasswordViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 146E47BC20DD746300C8F97F /* UsernameAndPasswordViewController.swift */; };
 		14E61C8020DD7C6200124E2B /* TableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 146E47BF20DD746300C8F97F /* TableViewController.swift */; };
 		14E61C8120DD7C6200124E2B /* LocationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 146E47B720DD746300C8F97F /* LocationViewController.swift */; };
 		14E61C8220DD7C6200124E2B /* LabelledTextViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 146E47BB20DD746300C8F97F /* LabelledTextViewCell.swift */; };
@@ -112,7 +112,7 @@
 		146E47B920DD746300C8F97F /* PlacemarkQuery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlacemarkQuery.swift; sourceTree = "<group>"; };
 		146E47BA20DD746300C8F97F /* CardCreatorConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardCreatorConfiguration.swift; sourceTree = "<group>"; };
 		146E47BB20DD746300C8F97F /* LabelledTextViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabelledTextViewCell.swift; sourceTree = "<group>"; };
-		146E47BC20DD746300C8F97F /* UsernameAndPINViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsernameAndPINViewController.swift; sourceTree = "<group>"; };
+		146E47BC20DD746300C8F97F /* UsernameAndPasswordViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsernameAndPasswordViewController.swift; sourceTree = "<group>"; };
 		146E47BD20DD746300C8F97F /* CardType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardType.swift; sourceTree = "<group>"; };
 		146E47BE20DD746300C8F97F /* AddressCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressCell.swift; sourceTree = "<group>"; };
 		146E47BF20DD746300C8F97F /* TableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TableViewController.swift; sourceTree = "<group>"; };
@@ -247,7 +247,7 @@
 				146E47C420DD746300C8F97F /* ConfirmValidAddressViewController.swift */,
 				146E47C220DD746300C8F97F /* AlternativeAddressesViewController.swift */,
 				146E47C920DD746300C8F97F /* NameAndEmailViewController.swift */,
-				146E47BC20DD746300C8F97F /* UsernameAndPINViewController.swift */,
+				146E47BC20DD746300C8F97F /* UsernameAndPasswordViewController.swift */,
 				146E47C320DD746300C8F97F /* UserSummaryViewController.swift */,
 				146E47C520DD746300C8F97F /* UserCredentialsViewController.swift */,
 			);
@@ -483,7 +483,7 @@
 				179267E92734D85D004EA5E7 /* FlowCoordinator.swift in Sources */,
 				14E61C7420DD7C6200124E2B /* PlacemarkQuery.swift in Sources */,
 				73935214246CD0C200ACC0AB /* FlowCoordinator+Juvenile.swift in Sources */,
-				14E61C7F20DD7C6200124E2B /* UsernameAndPINViewController.swift in Sources */,
+				14E61C7F20DD7C6200124E2B /* UsernameAndPasswordViewController.swift in Sources */,
 				14E61C7920DD7C6200124E2B /* AddressViewController.swift in Sources */,
 				14E61C7220DD7C6200124E2B /* SummaryCell.swift in Sources */,
 				14E61C8120DD7C6200124E2B /* LocationViewController.swift in Sources */,

--- a/NYPLCardCreator/BusinessLogic/AddressStep.swift
+++ b/NYPLCardCreator/BusinessLogic/AddressStep.swift
@@ -114,13 +114,13 @@ enum AddressStep {
       fallthrough
     case .standard:
       let (homeAddress, schoolOrWorkAddress) = self.pairWithAppendedAddress(address)
-      let nameAndEmailViewController = NameAndEmailViewController(
+      let userInfoViewController = UserPersonalInfoViewController(
         configuration: configuration,
         authToken: authToken,
         homeAddress: homeAddress,
         schoolOrWorkAddress: schoolOrWorkAddress,
         cardType: cardType)
-      viewController.navigationController?.pushViewController(nameAndEmailViewController, animated: true)
+      viewController.navigationController?.pushViewController(userInfoViewController, animated: true)
     case .juvenile:
       break
     }

--- a/NYPLCardCreator/BusinessLogic/CardCreatorConfiguration.swift
+++ b/NYPLCardCreator/BusinessLogic/CardCreatorConfiguration.swift
@@ -208,6 +208,7 @@ final class UserInfo {
   var middleName: String?
   var lastName: String?
   var email: String?
+  var birthdate: Date?
   
   var username: String?
 }

--- a/NYPLCardCreator/BusinessLogic/PasswordValidator.swift
+++ b/NYPLCardCreator/BusinessLogic/PasswordValidator.swift
@@ -9,9 +9,9 @@ enum PasswordValidationError {
   func errorMessage() -> String {
     switch self {
     case .invalidCount:
-      return NSLocalizedString("Password must be between 8 - 32 characters", comment: "The error message for the invalid password")
+      return NSLocalizedString("Password must be between 4 - 32 characters", comment: "The error message for the invalid password")
     case .invalidCharacter:
-      return NSLocalizedString("Password must be a combination of letters, numbers and the following symbols: ~ ! ? @ # $ % ^ & * ( ) ", comment: "The error message for the invalid password")
+      return NSLocalizedString("Password can only contain letters, numbers or the following symbols ~ ! ? @ # $ % ^ & * ( ) ", comment: "The error message for the invalid password")
     case .repeatingCharacter:
       return NSLocalizedString("Password cannot consecutively repeat a character 3 or more times", comment: "The error message for the invalid password")
     case .repeatingPattern:
@@ -22,14 +22,14 @@ enum PasswordValidationError {
 
 class PasswordValidator {
   /// Below are the rules for the password
-  /// 1. Password must be between 8 - 32 characters
+  /// 1. Password must be between 4 - 32 characters
   /// 2. Password can be a combination of numbers, uppercase / lowercase letters and the following symbols [~ ! ? @ # $ % ^ & * ( )]
   /// 3. Password cannot consecutively repeat a character 3 or more times, eg. aaa3ka2l
   /// 4. Password cannot consecutively repeat (2 or more times) a pattern of any 2, 3, or 4-character string. eg. 12341234
   static func validate(password: String?) -> PasswordValidationError? {
     // Rule 1
     guard let password = password,
-          password.count >= 8 && password.count <= 32 else {
+          password.count >= 4 && password.count <= 32 else {
       return .invalidCount
     }
     

--- a/NYPLCardCreator/BusinessLogic/PasswordValidator.swift
+++ b/NYPLCardCreator/BusinessLogic/PasswordValidator.swift
@@ -1,33 +1,54 @@
 import Foundation
 
+enum PasswordValidationError {
+  case invalidCount
+  case invalidCharacter
+  case repeatingCharacter
+  case repeatingPattern
+  
+  func errorMessage() -> String {
+    switch self {
+    case .invalidCount:
+      return NSLocalizedString("Password must be between 8 - 32 characters", comment: "The error message for the invalid password")
+    case .invalidCharacter:
+      return NSLocalizedString("Password must be a combination of letters, numbers and the following symbols: ~ ! ? @ # $ % ^ & * ( ) ", comment: "The error message for the invalid password")
+    case .repeatingCharacter:
+      return NSLocalizedString("Password cannot consecutively repeat a character 3 or more times", comment: "The error message for the invalid password")
+    case .repeatingPattern:
+      return NSLocalizedString("Password cannot consecutively repeat a pattern", comment: "The error message for the invalid password")
+    }
+  }
+}
+
 class PasswordValidator {
   /// Below are the rules for the password
   /// 1. Password must be between 8 - 32 characters
   /// 2. Password can be a combination of numbers, uppercase / lowercase letters and the following symbols [~ ! ? @ # $ % ^ & * ( )]
   /// 3. Password cannot consecutively repeat a character 3 or more times, eg. aaa3ka2l
   /// 4. Password cannot consecutively repeat (2 or more times) a pattern of any 2, 3, or 4-character string. eg. 12341234
-  static func validatePassword(_ password: String) -> Bool {
+  static func validate(password: String?) -> PasswordValidationError? {
     // Rule 1
-    guard password.count >= 8 && password.count <= 32 else {
-      return false
+    guard let password = password,
+          password.count >= 8 && password.count <= 32 else {
+      return .invalidCount
     }
     
     // Rule 2
     guard password.range(of: #"[^a-zA-Z0-9~!?@#$%^&*()]"#, options: .regularExpression) == nil else {
-      return false
+      return .invalidCharacter
     }
     
     // Rule 3
     guard password.range(of: #"(.)\1\1"#, options: .regularExpression) == nil else {
-      return false
+      return .repeatingCharacter
     }
     
     // Rule 4
     // "\w" might include underscore but we have already done character check above, so it should be safe
     guard password.range(of: #"([\w~!?@#$%^&*()]{2,4})\1+"#, options: .regularExpression) == nil else {
-      return false
+      return .repeatingPattern
     }
     
-    return true
+    return nil
   }
 }

--- a/NYPLCardCreator/BusinessLogic/PatronCreationInfo.swift
+++ b/NYPLCardCreator/BusinessLogic/PatronCreationInfo.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+// This class looks similar to UserInfo but
+// this is designed to store info ready to be send to server,
+// while UserInfo is designed to store info entered by user.
+final class PatronCreationInfo {
+  var name: String
+  var email: String
+  var username: String
+  var password: String
+  var homeAddress: Address
+  var workAddress: Address?
+  var birthdate: String?
+  
+  init(name: String,
+       email: String,
+       birthdate: String?,
+       username: String,
+       password: String,
+       homeAddress: Address,
+       workAddress: Address?)
+  {
+    self.name = name
+    self.email = email
+    self.birthdate = birthdate
+    self.username = username
+    self.password = password
+    self.homeAddress = homeAddress
+    self.workAddress = workAddress
+  }
+  
+  func JSONObject() -> [String: AnyObject] {
+    let workAddressOrNull: AnyObject = {
+      if let workAddress = self.workAddress {
+        return workAddress.JSONObject() as AnyObject
+      } else {
+        return NSNull()
+      }
+    }()
+    
+    return [
+      "name": self.name as AnyObject,
+      "email": self.email as AnyObject,
+      "username": self.username as AnyObject,
+      "pin": self.password as AnyObject,
+      "address": self.homeAddress.JSONObject() as AnyObject,
+      "workAddress": workAddressOrNull,
+      "usernameHasBeenValidated": true as AnyObject,
+      "policyType": "simplye" as AnyObject,
+      "ageGate": true as AnyObject,
+      "acceptTerms": true as AnyObject,
+      "birthdate": (self.birthdate ?? "") as AnyObject
+    ]
+  }
+}

--- a/NYPLCardCreator/BusinessLogic/PatronCreationInfo.swift
+++ b/NYPLCardCreator/BusinessLogic/PatronCreationInfo.swift
@@ -3,7 +3,7 @@ import Foundation
 // This class looks similar to UserInfo but
 // this is designed to store info ready to be send to server,
 // while UserInfo is designed to store info entered by user.
-final class PatronCreationInfo {
+struct PatronCreationInfo {
   var name: String
   var email: String
   var username: String
@@ -49,7 +49,7 @@ final class PatronCreationInfo {
       "policyType": "simplye" as AnyObject,
       "ageGate": true as AnyObject,
       "acceptTerms": true as AnyObject,
-      "birthdate": (self.birthdate ?? "") as AnyObject
+      "birthdate": self.birthdate as AnyObject
     ]
   }
 }

--- a/NYPLCardCreator/Flow/AddressViewController.swift
+++ b/NYPLCardCreator/Flow/AddressViewController.swift
@@ -302,40 +302,23 @@ final class AddressViewController: FormTableViewController {
         self.navigationController?.view.isUserInteractionEnabled = true
         self.navigationItem.titleView = nil
         if let error = error {
-          let alertController = UIAlertController(
-            title: NSLocalizedString("Error", comment: "The title for an error alert"),
-            message: error.localizedDescription,
-            preferredStyle: .alert)
-          alertController.addAction(UIAlertAction(
-            title: NSLocalizedString("OK", comment: ""),
-            style: .default,
-            handler: nil))
-          self.present(alertController, animated: true, completion: nil)
+          self.showErrorAlert(message: error.localizedDescription)
           return
-        }
-        func showErrorAlert() {
-          let alertController = UIAlertController(
-            title: NSLocalizedString("Error", comment: "The title for an error alert"),
-            message: NSLocalizedString(
-              "A server error occurred during address validation. Please try again later.",
-              comment: "An alert message explaining an error and telling the user to try again later"),
-            preferredStyle: .alert)
-          alertController.addAction(UIAlertAction(
-            title: NSLocalizedString("OK", comment: ""),
-            style: .default,
-            handler: nil))
-          self.present(alertController, animated: true, completion: nil)
         }
         // While responses with status code 400 are mostly errors, we need to handle the error
         // on a case by case basis (eg. alternate addresses) in the ValidateAddressResponse class
         if (response as! HTTPURLResponse).statusCode != 200 &&
             (response as! HTTPURLResponse).statusCode != 400 ||
             data == nil {
-          showErrorAlert()
+          self.showErrorAlert(message: NSLocalizedString(
+                                "A server error occurred during address validation. Please try again later.",
+                                comment: "An alert message explaining an error and telling the user to try again later"))
           return
         }
         guard let validateAddressResponse = ValidateAddressResponse.responseWithData(data!) else {
-          showErrorAlert()
+          self.showErrorAlert(message: NSLocalizedString(
+                                "A server error occurred during address validation. Please try again later.",
+                                comment: "An alert message explaining an error and telling the user to try again later"))
           return
         }
         switch validateAddressResponse {
@@ -361,19 +344,13 @@ final class AddressViewController: FormTableViewController {
             alternativeAddressesAndCardTypes: addressesAndCardTypes)
           self.navigationController?.pushViewController(viewController, animated: true)
         case .unrecognizedAddress:
-          let alertController = UIAlertController(
-            title: NSLocalizedString(
-              "Unrecognized Address",
-              comment: "An alert title telling the user their address was not recognized by the server"),
-            message: NSLocalizedString(
-              "Your address could not be verified. Please try another address.",
-              comment: "An alert message telling the user their address was not recognized by the server"),
-            preferredStyle: .alert)
-          alertController.addAction(UIAlertAction(
-            title: NSLocalizedString("OK", comment: ""),
-            style: .default,
-            handler: nil))
-          self.present(alertController, animated: true, completion: nil)
+          let title = NSLocalizedString(
+            "Unrecognized Address",
+            comment: "An alert title telling the user their address was not recognized by the server")
+          let message = NSLocalizedString(
+            "Your address could not be verified. Please try another address.",
+            comment: "An alert message telling the user their address was not recognized by the server")
+          self.showErrorAlert(title: title, message: message)
         }
       }
     }

--- a/NYPLCardCreator/Flow/AddressViewController.swift
+++ b/NYPLCardCreator/Flow/AddressViewController.swift
@@ -307,6 +307,7 @@ final class AddressViewController: FormTableViewController {
         }
         // While responses with status code 400 are mostly errors, we need to handle the error
         // on a case by case basis (eg. alternate addresses) in the ValidateAddressResponse class
+        // API: https://github.com/NYPL/dgx-patron-creator-service/wiki/API-V0.3
         if (response as! HTTPURLResponse).statusCode != 200 &&
             (response as! HTTPURLResponse).statusCode != 400 ||
             data == nil {

--- a/NYPLCardCreator/Flow/LocationViewController.swift
+++ b/NYPLCardCreator/Flow/LocationViewController.swift
@@ -91,7 +91,7 @@ final class LocationViewController: UIViewController {
   @objc private func didSelectNext() {
     let vc: UIViewController
     if configuration.isJuvenile {
-      vc = NameAndEmailViewController(juvenileConfiguration: configuration, authToken: authToken)
+      vc = UserPersonalInfoViewController(juvenileConfiguration: configuration, authToken: authToken)
     } else {
       vc = AddressViewController(configuration: self.configuration,
                                  authToken: authToken,

--- a/NYPLCardCreator/Flow/NameAndEmailViewController.swift
+++ b/NYPLCardCreator/Flow/NameAndEmailViewController.swift
@@ -156,7 +156,7 @@ final class NameAndEmailViewController: FormTableViewController {
                                           lastName: lastName)
 
     self.navigationController?.pushViewController(
-      UsernameAndPINViewController(
+      UsernameAndPasswordViewController(
         configuration: self.configuration,
         authToken: authToken,
         homeAddress: self.homeAddress,

--- a/NYPLCardCreator/Flow/UserSummaryViewController.swift
+++ b/NYPLCardCreator/Flow/UserSummaryViewController.swift
@@ -23,14 +23,14 @@ final class UserSummaryViewController: TableViewController, JuvenileCardCreation
   private let fullNameCell: SummaryCell
   private let emailCell: SummaryCell
   private let usernameCell: SummaryCell
-  private let pinCell: SummaryCell
+  private let passwordCell: SummaryCell
   
   private let homeAddress: Address
   private let schoolOrWorkAddress: Address?
   private let fullName: String
   private let email: String
   private let username: String
-  private let pin: String
+  private let password: String
 
   init(
     configuration: CardCreatorConfiguration,
@@ -41,7 +41,7 @@ final class UserSummaryViewController: TableViewController, JuvenileCardCreation
     fullName: String,
     email: String,
     username: String,
-    pin: String)
+    password: String)
   {
     self.configuration = configuration
     self.authToken = authToken
@@ -53,7 +53,7 @@ final class UserSummaryViewController: TableViewController, JuvenileCardCreation
     self.fullName = fullName
     self.email = email
     self.username = username
-    self.pin = pin
+    self.password = password
     
     self.headerLabel = UILabel()
     
@@ -77,14 +77,14 @@ final class UserSummaryViewController: TableViewController, JuvenileCardCreation
                                  cellText: self.email)
     self.usernameCell = SummaryCell(section: NSLocalizedString("Username", comment: "Title of the section for the user's chosen username"),
                                     cellText: self.username)
-    self.pinCell = SummaryCell(section: NSLocalizedString("Pin", comment: "Title of the section for the user's PIN number"),
-                               cellText: self.pin)
+    self.passwordCell = SummaryCell(section: NSLocalizedString("Password", comment: "Title of the section for the user's chosen password"),
+                               cellText: self.password)
 
     if configuration.isJuvenile {
       self.cells = [
         self.fullNameCell,
         self.usernameCell,
-        self.pinCell
+        self.passwordCell
       ]
     } else {
       self.cells = [
@@ -92,7 +92,7 @@ final class UserSummaryViewController: TableViewController, JuvenileCardCreation
         self.fullNameCell,
         self.emailCell,
         self.usernameCell,
-        self.pinCell
+        self.passwordCell
       ]
     }
 
@@ -210,7 +210,7 @@ final class UserSummaryViewController: TableViewController, JuvenileCardCreation
     let info = JuvenileCreationInfo(parentBarcode: configuration.juvenileParentBarcode,
                                     name: fullName,
                                     username: username,
-                                    pin: pin)
+                                    pin: password)
     configuration.juvenileCreationHandler?(info, self)
   }
 
@@ -229,7 +229,7 @@ final class UserSummaryViewController: TableViewController, JuvenileCardCreation
           UserCredentialsViewController(configuration: self.configuration,
                                         username: self.username,
                                         barcode: juvenileBarcode,
-                                        pin: self.pin,
+                                        pin: self.password,
                                         cardType: self.cardType),
           animated: true)
       case .fail(let error):
@@ -261,7 +261,7 @@ final class UserSummaryViewController: TableViewController, JuvenileCardCreation
       "email": self.email as AnyObject,
       "address": self.homeAddress.JSONObject() as AnyObject,
       "username": self.username as AnyObject,
-      "pin": self.pin as AnyObject,
+      "pin": self.password as AnyObject,
       "work_or_school_address": schoolOrWorkAddressOrNull
     ]
     request.httpBody = try! JSONSerialization.data(withJSONObject: JSONObject, options: [.prettyPrinted])
@@ -309,7 +309,7 @@ final class UserSummaryViewController: TableViewController, JuvenileCardCreation
       UserCredentialsViewController(configuration: self.configuration,
                                     username: self.username,
                                     barcode: barcode,
-                                    pin: self.pin,
+                                    pin: self.password,
                                     cardType: self.cardType),
       animated: true)
   }

--- a/NYPLCardCreator/Flow/UserSummaryViewController.swift
+++ b/NYPLCardCreator/Flow/UserSummaryViewController.swift
@@ -265,18 +265,13 @@ final class UserSummaryViewController: TableViewController, JuvenileCardCreation
       return
     }
 
+    // Response with status 400 contains informative error message for alert
+    // API: https://github.com/NYPL/dgx-patron-creator-service/wiki/API-V0.3
     guard let httpResponse = response as? HTTPURLResponse,
       httpResponse.statusCode == 200 || httpResponse.statusCode == 400,
       let data = data,
       let JSONObject = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: AnyObject] else {
-
-        var errMsg = ""
-        if let code = (response as? HTTPURLResponse)?.statusCode {
-          errMsg = "\nError code: \(code)"
-        }
-        showErrorAlert(NSLocalizedString(
-          "A server error occurred during card creation. Please try again later.\(errMsg)",
-          comment: "An alert message explaining an error and telling the user to try again later"))
+        showErrorAlert()
         return
     }
     

--- a/NYPLCardCreator/Flow/UsernameAndPasswordViewController.swift
+++ b/NYPLCardCreator/Flow/UsernameAndPasswordViewController.swift
@@ -196,6 +196,8 @@ Password should be
           return
         }
 
+        // Response with status 400 contains informative error message for alert
+        // API: https://github.com/NYPL/dgx-patron-creator-service/wiki/API-V0.3
         guard let response = response as? HTTPURLResponse,
           response.statusCode == 200 || response.statusCode == 400,
           let data = data,

--- a/NYPLCardCreator/ReusedUIComponents/FormTableViewController.swift
+++ b/NYPLCardCreator/ReusedUIComponents/FormTableViewController.swift
@@ -83,4 +83,26 @@ class FormTableViewController: TableViewController, UITextFieldDelegate {
   @objc func didSelectNext() {
     
   }
+  
+  /// - parameter title: If missing, defaults to generic error title.
+  /// - parameter message: If missing, defaults to generic error message.
+  func showErrorAlert(title: String? = nil, message: String? = nil) {
+    let alertTitle = title ?? NSLocalizedString(
+      "Error",
+      comment: "The title for an error alert")
+
+    let alertMessage = message ?? NSLocalizedString(
+      "An error occurred. Please try again later.",
+      comment: "An alert message explaining an error and telling the user to try again later")
+
+    let alertController = UIAlertController(
+      title: alertTitle,
+      message: alertMessage,
+      preferredStyle: .alert)
+    alertController.addAction(UIAlertAction(
+      title: NSLocalizedString("OK", comment: ""),
+      style: .default,
+      handler: nil))
+    self.present(alertController, animated: true, completion: nil)
+  }
 }

--- a/NYPLCardCreatorTests/PasswordValidationTests.swift
+++ b/NYPLCardCreatorTests/PasswordValidationTests.swift
@@ -3,53 +3,52 @@ import XCTest
 
 class PasswordValidationTests: XCTestCase {
   func testPasswordCharacterCount() throws {
-    XCTAssertFalse(PasswordValidator.validatePassword("1234567"))
-    
-    XCTAssertTrue(PasswordValidator.validatePassword("12345678"))
+    XCTAssertNil(PasswordValidator.validate(password: "12345678"), "Password is valid")
+    XCTAssertEqual(PasswordValidator.validate(password: "1234567"), .invalidCount)
     
     let stringWithMaxCharacters = "abcdefghijklmnopqrstuvwxyz123456"
-    XCTAssertTrue(PasswordValidator.validatePassword(stringWithMaxCharacters))
+    XCTAssertNil(PasswordValidator.validate(password: "12345678"), "Password character count is valid")
     
-    XCTAssertFalse(PasswordValidator.validatePassword(stringWithMaxCharacters + "a"))
+    XCTAssertEqual(PasswordValidator.validate(password: stringWithMaxCharacters + "a"), .invalidCount)
   }
   
   func testSymbols() throws {
     let validSymbolString = #"~!?@#$%^&*()"#
-    XCTAssertTrue(PasswordValidator.validatePassword(validSymbolString))
+    XCTAssertNil(PasswordValidator.validate(password: validSymbolString), "Password is valid")
     
-    XCTAssertFalse(PasswordValidator.validatePassword("asdfg_<"))
-    XCTAssertFalse(PasswordValidator.validatePassword("asdfg_>"))
-    XCTAssertFalse(PasswordValidator.validatePassword(#"asdfg_\"#))
-    XCTAssertFalse(PasswordValidator.validatePassword("asdfg_/"))
-    XCTAssertFalse(PasswordValidator.validatePassword("asdfg_."))
-    XCTAssertFalse(PasswordValidator.validatePassword("asdfg_ "))
+    XCTAssertEqual(PasswordValidator.validate(password: "1234567<"), .invalidCharacter)
+    XCTAssertEqual(PasswordValidator.validate(password: "1234567>"), .invalidCharacter)
+    XCTAssertEqual(PasswordValidator.validate(password: #"1234567\"#), .invalidCharacter)
+    XCTAssertEqual(PasswordValidator.validate(password: "1234567/"), .invalidCharacter)
+    XCTAssertEqual(PasswordValidator.validate(password: "1234567."), .invalidCharacter)
+    XCTAssertEqual(PasswordValidator.validate(password: "1234567 "), .invalidCharacter)
   }
 
   func testRepeatingCharacters() throws {
-    XCTAssertTrue(PasswordValidator.validatePassword("aabbccddeeffgg"))
+    XCTAssertNil(PasswordValidator.validate(password: "aabbccddeeffgg"), "Password is valid")
     
-    XCTAssertFalse(PasswordValidator.validatePassword("1234444asd"))
-    XCTAssertFalse(PasswordValidator.validatePassword("111asbciwhnk@#$"))
-    XCTAssertFalse(PasswordValidator.validatePassword("123aaa567"))
-    XCTAssertFalse(PasswordValidator.validatePassword("abcdefg00000000000000"))
-    XCTAssertFalse(PasswordValidator.validatePassword("aolghe$$$$$"))
-    XCTAssertFalse(PasswordValidator.validatePassword("123@@@mcns"))
+    XCTAssertEqual(PasswordValidator.validate(password: "1234444asd"), .repeatingCharacter)
+    XCTAssertEqual(PasswordValidator.validate(password: "111asbciwhnk@#$"), .repeatingCharacter)
+    XCTAssertEqual(PasswordValidator.validate(password: "123aaa567"), .repeatingCharacter)
+    XCTAssertEqual(PasswordValidator.validate(password: "abcdefg00000000000000"), .repeatingCharacter)
+    XCTAssertEqual(PasswordValidator.validate(password: "aolghe$$$$$"), .repeatingCharacter)
+    XCTAssertEqual(PasswordValidator.validate(password: "123@@@mcns"), .repeatingCharacter)
   }
   
   func testRepeatingPatterns() throws {
-    XCTAssertTrue(PasswordValidator.validatePassword("aa4567aa"))
-    XCTAssertTrue(PasswordValidator.validatePassword("abc12abc"))
-    XCTAssertTrue(PasswordValidator.validatePassword("aabb234bbaa"))
-    XCTAssertTrue(PasswordValidator.validatePassword("1234512345"))
-    XCTAssertTrue(PasswordValidator.validatePassword("~~aa~~AA"))
-    XCTAssertTrue(PasswordValidator.validatePassword("~~aa~~AA~~aa"))
+    XCTAssertNil(PasswordValidator.validate(password: "aa4567aa"), "Password is valid")
+    XCTAssertNil(PasswordValidator.validate(password: "abc12abc"), "Password is valid")
+    XCTAssertNil(PasswordValidator.validate(password: "aabb234bbaa"), "Password is valid")
+    XCTAssertNil(PasswordValidator.validate(password: "1234512345"), "Password is valid")
+    XCTAssertNil(PasswordValidator.validate(password: "~~aa~~AA"), "Password is valid")
+    XCTAssertNil(PasswordValidator.validate(password: "~~aa~~AA~~aa"), "Password is valid")
     
-    XCTAssertFalse(PasswordValidator.validatePassword("ab1212ab"))
-    XCTAssertFalse(PasswordValidator.validatePassword("12124545"))
-    XCTAssertFalse(PasswordValidator.validatePassword("abcabc12"))
-    XCTAssertFalse(PasswordValidator.validatePassword("~!@~!@~!@~!@~!@"))
-    XCTAssertFalse(PasswordValidator.validatePassword("abcdabcd"))
-    XCTAssertFalse(PasswordValidator.validatePassword("~~aa~~aa"))
-    XCTAssertFalse(PasswordValidator.validatePassword("~~aa~~AA~~aa~~aa"))
+    XCTAssertEqual(PasswordValidator.validate(password: "ab1212ab"), .repeatingPattern)
+    XCTAssertEqual(PasswordValidator.validate(password: "12124545"), .repeatingPattern)
+    XCTAssertEqual(PasswordValidator.validate(password: "abcabc12"), .repeatingPattern)
+    XCTAssertEqual(PasswordValidator.validate(password: "~!@~!@~!@~!@~!@"), .repeatingPattern)
+    XCTAssertEqual(PasswordValidator.validate(password: "abcdabcd"), .repeatingPattern)
+    XCTAssertEqual(PasswordValidator.validate(password: "~~aa~~aa"), .repeatingPattern)
+    XCTAssertEqual(PasswordValidator.validate(password: "~~aa~~AA~~aa~~aa"), .repeatingPattern)
   }
 }

--- a/NYPLCardCreatorTests/PasswordValidationTests.swift
+++ b/NYPLCardCreatorTests/PasswordValidationTests.swift
@@ -3,11 +3,11 @@ import XCTest
 
 class PasswordValidationTests: XCTestCase {
   func testPasswordCharacterCount() throws {
-    XCTAssertNil(PasswordValidator.validate(password: "12345678"), "Password is valid")
-    XCTAssertEqual(PasswordValidator.validate(password: "1234567"), .invalidCount)
+    XCTAssertNil(PasswordValidator.validate(password: "1234"), "Password is valid")
+    XCTAssertEqual(PasswordValidator.validate(password: "123"), .invalidCount)
     
     let stringWithMaxCharacters = "abcdefghijklmnopqrstuvwxyz123456"
-    XCTAssertNil(PasswordValidator.validate(password: "12345678"), "Password character count is valid")
+    XCTAssertNil(PasswordValidator.validate(password: stringWithMaxCharacters), "Password character count is valid")
     
     XCTAssertEqual(PasswordValidator.validate(password: stringWithMaxCharacters + "a"), .invalidCount)
   }


### PR DESCRIPTION
**What's this do?**
Switch to new API for username validation and patron creation
Implement UI for birthdate entry and password validation

**Why are we doing this? (w/ JIRA link if applicable)**
[ios-232](https://jira.nypl.org/browse/IOS-232)
In order to submit the alphanumeric password to server-side, we need to switch to the new [API](https://github.com/NYPL/dgx-patron-creator-service/wiki/API-V0.3)

**How should this be tested? / Do these changes have associated tests?**
Not ready to be tested

**Dependencies for merging? Releasing to production?**
N/A

**Does this include changes that require a new SimplyE/Open eBooks build for QA?**
N/A

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@ErnestFan tested with SE
