### PR TITLE
IOS-298 Parse full error messages

### DIFF
--- a/NYPLCardCreator.xcodeproj/project.pbxproj
+++ b/NYPLCardCreator.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		7353354D246DBB8D000C2874 /* ResultErrors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7353354C246DBB8D000C2874 /* ResultErrors.swift */; };
 		735F6379247DDDB6008858C4 /* JuvenileCreationResponseBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = 735F6378247DDDB6008858C4 /* JuvenileCreationResponseBody.swift */; };
 		736D97A52559EB1300843709 /* CardCreatorConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 736D97A42559EB1300843709 /* CardCreatorConfigurationTests.swift */; };
+		736F6ACD27628D1900BD6A0B /* PlatformAPIErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 736F6ACC27628D1900BD6A0B /* PlatformAPIErrorTests.swift */; };
 		738401032474974000236B0D /* ISSOToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 738401022474974000236B0D /* ISSOToken.swift */; };
 		73935214246CD0C200ACC0AB /* FlowCoordinator+Juvenile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73935213246CD0C200ACC0AB /* FlowCoordinator+Juvenile.swift */; };
 		73D15456247C96C700ACD04E /* JuvenileCreationInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73D15455247C96C700ACD04E /* JuvenileCreationInfo.swift */; };
@@ -149,6 +150,7 @@
 		7353354C246DBB8D000C2874 /* ResultErrors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResultErrors.swift; sourceTree = "<group>"; };
 		735F6378247DDDB6008858C4 /* JuvenileCreationResponseBody.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JuvenileCreationResponseBody.swift; sourceTree = "<group>"; };
 		736D97A42559EB1300843709 /* CardCreatorConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardCreatorConfigurationTests.swift; sourceTree = "<group>"; };
+		736F6ACC27628D1900BD6A0B /* PlatformAPIErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlatformAPIErrorTests.swift; sourceTree = "<group>"; };
 		738401022474974000236B0D /* ISSOToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ISSOToken.swift; sourceTree = "<group>"; };
 		73935213246CD0C200ACC0AB /* FlowCoordinator+Juvenile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FlowCoordinator+Juvenile.swift"; sourceTree = "<group>"; };
 		73D15455247C96C700ACD04E /* JuvenileCreationInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JuvenileCreationInfo.swift; sourceTree = "<group>"; };
@@ -311,9 +313,10 @@
 			isa = PBXGroup;
 			children = (
 				73EEE7E3247F274E00A06D14 /* Info.plist */,
-				73EEE7EC247F290700A06D14 /* JuvenileCreationResponseBodyTests.swift */,
 				736D97A42559EB1300843709 /* CardCreatorConfigurationTests.swift */,
+				73EEE7EC247F290700A06D14 /* JuvenileCreationResponseBodyTests.swift */,
 				17B17A99272BAE2000314AF6 /* PasswordValidationTests.swift */,
+				736F6ACC27628D1900BD6A0B /* PlatformAPIErrorTests.swift */,
 			);
 			path = NYPLCardCreatorTests;
 			sourceTree = "<group>";
@@ -534,6 +537,7 @@
 				17B17A9A272BAE2000314AF6 /* PasswordValidationTests.swift in Sources */,
 				73EEE7ED247F290700A06D14 /* JuvenileCreationResponseBodyTests.swift in Sources */,
 				736D97A52559EB1300843709 /* CardCreatorConfigurationTests.swift in Sources */,
+				736F6ACD27628D1900BD6A0B /* PlatformAPIErrorTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/NYPLCardCreator/BusinessLogic/FlowCoordinator+Juvenile.swift
+++ b/NYPLCardCreator/BusinessLogic/FlowCoordinator+Juvenile.swift
@@ -172,7 +172,7 @@ public extension FlowCoordinator {
         // NB: the server will return product-approved yet non-localized
         // messages, but because of time constraints we are not going to
         // localize those
-        userInfo[NSLocalizedDescriptionKey] = responseError.message
+        userInfo[NSLocalizedDescriptionKey] = responseError.fullErrorDetails
         completion(NSError(domain: ErrorDomain,
                            code: ErrorCode.ineligibleForJuvenileCardCreation.rawValue,
                            userInfo: userInfo))
@@ -241,7 +241,7 @@ public extension FlowCoordinator {
         completion(.fail(NSError(domain: ErrorDomain,
                                  code: ErrorCode.createJuvenileAccountFail.rawValue,
                                  userInfo: [
-                                  NSLocalizedDescriptionKey: error.message,
+                                  NSLocalizedDescriptionKey: error.fullErrorDetails,
                                   "requestURL": urlStr,
                                   "response": response])))
         return

--- a/NYPLCardCreator/BusinessLogic/PlatformAPIError.swift
+++ b/NYPLCardCreator/BusinessLogic/PlatformAPIError.swift
@@ -17,8 +17,38 @@ struct PlatformAPIError: Decodable {
   /// Error type
   let type: String?
 
-  /// User-friendly error message
-  let message: String
+  /// A subject for what went wrong.
+  let title: String?
+
+  /// User-friendly error message, usually a succint summary.
+  let detail: String?
+
+  /// Legacy user-friendly error message
+  let message: String?
+
+  /// This contains more specific and informative error causes.
+  let error: [String: String]?
+
+  /// Collates `detail` and `error` values into one string, after sorting the
+  /// `error` key-value pairs by key.
+  var fullErrorDetails: String {
+    let errorHash = error ?? [:]
+
+    let sortedHash = errorHash.sorted { kvPair1, kvPair2 in
+      kvPair1.key.lowercased() < kvPair2.key.lowercased()
+    }
+
+    let msg = sortedHash.reduce(detail ?? message ?? "") { partialResult, val in
+      partialResult + "\n" + val.value
+    }
+
+    if msg.isEmpty {
+      return NSLocalizedString("An error occurred. Please try again later.",
+                               comment: "A fallback error message")
+    }
+
+    return msg
+  }
 
   static func fromData(_ data: Data) -> PlatformAPIError? {
     let decoder = JSONDecoder()

--- a/NYPLCardCreatorTests/PlatformAPIErrorTests.swift
+++ b/NYPLCardCreatorTests/PlatformAPIErrorTests.swift
@@ -1,0 +1,130 @@
+//
+//  PlatformAPIErrorTests.swift
+//  NYPLCardCreatorTests
+//
+//  Created by Ettore Pasquini on 12/9/21.
+//  Copyright © 2021 NYPL Labs. All rights reserved.
+//
+
+import XCTest
+@testable import NYPLCardCreator
+
+class PlatformAPIErrorTests: XCTestCase {
+
+  override func setUpWithError() throws {
+  }
+
+  override func tearDownWithError() throws {
+  }
+
+  func testParseFullyQualifiedError() throws {
+    let jsonString = """
+    {
+      "status": 400,
+      "type": "invalid-request",
+      "title": "Invalid Request",
+      "detail": "Here is the detail.",
+      "message": "Here is the message.",
+      "name": "The name",
+      "error": {
+        "email": "Email is wrong.",
+        "password": "Password is messed up.",
+        "birthdate": "Bday ain't right."
+      }
+    }
+    """
+    let jsonData = jsonString.data(using: .utf8)
+
+    // test
+    let error = PlatformAPIError.fromData(jsonData!)
+
+    // verify
+    guard let error = error else {
+      XCTFail("couldn't parse error")
+      return
+    }
+    XCTAssertEqual(error.status, 400)
+    XCTAssertEqual(error.type, "invalid-request")
+    XCTAssertEqual(error.title, "Invalid Request")
+    XCTAssertEqual(error.detail, "Here is the detail.")
+    XCTAssertEqual(error.message, "Here is the message.")
+    XCTAssertEqual(error.fullErrorDetails, """
+      Here is the detail.
+      Bday ain't right.
+      Email is wrong.
+      Password is messed up.
+      """)
+  }
+
+  func testParseMinimalError() throws {
+    let jsonString = """
+    {
+      "status": 502,
+      "type": "ils-integration-error",
+      "message": "The ILS messed up.",
+    }
+    """
+    let jsonData = jsonString.data(using: .utf8)
+
+    // test
+    let error = PlatformAPIError.fromData(jsonData!)
+
+    // verify
+    guard let error = error else {
+      XCTFail("couldn't parse error")
+      return
+    }
+    XCTAssertEqual(error.status, 502)
+    XCTAssertEqual(error.type, "ils-integration-error")
+    XCTAssertNil(error.detail)
+    XCTAssertEqual(error.message, "The ILS messed up.")
+    XCTAssertEqual(error.fullErrorDetails, """
+      The ILS messed up.
+      """)
+  }
+
+  func testParseEmptyErrorHash() throws {
+    let jsonString = """
+    {
+      "status": 500,
+      "error": {}
+    }
+    """
+    let jsonData = jsonString.data(using: .utf8)
+
+    // test
+    let error = PlatformAPIError.fromData(jsonData!)
+
+    // verify
+    guard let error = error else {
+      XCTFail("couldn't parse error")
+      return
+    }
+    XCTAssertEqual(error.status, 500)
+    XCTAssertEqual(error.fullErrorDetails, """
+      An error occurred. Please try again later.
+      """)
+  }
+
+  func testParseBareMinimalError() throws {
+    let jsonString = """
+    {
+      "status": 401,
+    }
+    """
+    let jsonData = jsonString.data(using: .utf8)
+
+    // test
+    let error = PlatformAPIError.fromData(jsonData!)
+
+    // verify
+    guard let error = error else {
+      XCTFail("couldn't parse error")
+      return
+    }
+    XCTAssertEqual(error.status, 401)
+    XCTAssertEqual(error.fullErrorDetails, """
+      An error occurred. Please try again later.
+      """)
+  }
+}


### PR DESCRIPTION
For any error situation during patron creation, we now parse the error contents from PlatformAPI collating all key-value pair details in the `error` dictionary into a string, so that that can be displayed to the user.

Since the PlatformAPI is now used by both regular and juvenile flows, we can reuse this error parsing in both places.