### PR TITLE
IOS-320 Fix Bundle reference for locating resources

### DIFF
--- a/NYPLCardCreator/Flow/IntroductionViewController.swift
+++ b/NYPLCardCreator/Flow/IntroductionViewController.swift
@@ -263,7 +263,7 @@ final class IntroductionViewController: UIViewController, UITableViewDelegate, U
   }
   
   private func setCheckmark(_ state: Bool, forCell cell: UITableViewCell?) {
-    let bundle = Bundle(for: type(of: self))
+    let bundle = Bundle.module
     if (state == true) {
       let image = UIImage(named: "CheckboxOn", in: bundle, compatibleWith: nil)?.withRenderingMode(.alwaysTemplate)
       let imageView = UIImageView(image: image)

--- a/NYPLCardCreator/Helpers/Bundle+CardCreator.swift
+++ b/NYPLCardCreator/Helpers/Bundle+CardCreator.swift
@@ -1,0 +1,19 @@
+//
+//  Bundle+CardCreator.swift
+//  Created by Ettore Pasquini on 1/18/22.
+//  Copyright © 2022 NYPL. All rights reserved.
+//
+
+#if !SWIFT_PACKAGE
+
+import Foundation
+
+private class NYPLCardCreatorDummy {}
+
+extension Bundle {
+  static var module: Bundle {
+    return Bundle(for: type(of: NYPLCardCreatorDummy))
+  }
+}
+
+#endif


### PR DESCRIPTION
When building the module with SPM the Bundle for the module needs to be specified differently than when we build via Xcode project. A `module` computed property is being added behind the scenes when building with SPM, but that property is not available when building without it. While we are now only building CardCreator with SPM, I added an equivalent property for good measure.