### PR TITLE
iOS-307 Update API request with location string

### DIFF
--- a/NYPLCardCreator/BusinessLogic/CardCreatorConfiguration.swift
+++ b/NYPLCardCreator/BusinessLogic/CardCreatorConfiguration.swift
@@ -206,6 +206,11 @@ final class UserInfo {
   var lastName: String?
   var email: String?
   var birthdate: Date?
+  /// A string to determine user location for patron creation request
+  /// eg. nyc for user within new york city,
+  ///    nys for user within new york state,
+  ///    us for user within us but outside new york state,
+  ///    otherwise an empty string
   var location: String?
   
   var username: String?

--- a/NYPLCardCreator/BusinessLogic/CardCreatorConfiguration.swift
+++ b/NYPLCardCreator/BusinessLogic/CardCreatorConfiguration.swift
@@ -206,6 +206,7 @@ final class UserInfo {
   var lastName: String?
   var email: String?
   var birthdate: Date?
+  var location: String?
   
   var username: String?
 }

--- a/NYPLCardCreator/BusinessLogic/PatronCreationInfo.swift
+++ b/NYPLCardCreator/BusinessLogic/PatronCreationInfo.swift
@@ -11,6 +11,7 @@ struct PatronCreationInfo {
   var homeAddress: Address
   var workAddress: Address?
   var birthdate: String?
+  var location: String
   
   init(name: String,
        email: String,
@@ -18,7 +19,8 @@ struct PatronCreationInfo {
        username: String,
        password: String,
        homeAddress: Address,
-       workAddress: Address?)
+       workAddress: Address?,
+       location:String)
   {
     self.name = name
     self.email = email
@@ -27,6 +29,7 @@ struct PatronCreationInfo {
     self.password = password
     self.homeAddress = homeAddress
     self.workAddress = workAddress
+    self.location = location
   }
   
   func JSONObject() -> [String: AnyObject] {
@@ -49,7 +52,8 @@ struct PatronCreationInfo {
       "policyType": "simplye" as AnyObject,
       "ageGate": true as AnyObject,
       "acceptTerms": true as AnyObject,
-      "birthdate": self.birthdate as AnyObject
+      "birthdate": self.birthdate as AnyObject,
+      "location": self.location as AnyObject
     ]
   }
 }

--- a/NYPLCardCreator/Flow/LocationViewController.swift
+++ b/NYPLCardCreator/Flow/LocationViewController.swift
@@ -116,9 +116,9 @@ final class LocationViewController: UIViewController {
           comment: "A label title informing the user that their location could not be determined")
         self.present(alertController, animated: true, completion: nil)
       case let .placemark(placemark):
-        let location = placemark.getLocationString()
-        if placemark.administrativeArea == "NY" {
-          self.configuration.user.location = location
+        if let state = placemark.administrativeArea?.lowercased(),
+           state == "ny" || state == "new york" {
+          self.configuration.user.location = placemark.getLocationString()
           self.navigationItem.rightBarButtonItem?.isEnabled = true
           self.resultLabel.text = NSLocalizedString(
             "We have successfully determined that you are in New York!",

--- a/NYPLCardCreator/Flow/LocationViewController.swift
+++ b/NYPLCardCreator/Flow/LocationViewController.swift
@@ -1,4 +1,5 @@
 import UIKit
+import CoreLocation
 
 /// The second step in the card registration flow.
 final class LocationViewController: UIViewController {
@@ -115,7 +116,9 @@ final class LocationViewController: UIViewController {
           comment: "A label title informing the user that their location could not be determined")
         self.present(alertController, animated: true, completion: nil)
       case let .placemark(placemark):
+        let location = placemark.getLocationString()
         if placemark.administrativeArea == "NY" {
+          self.configuration.user.location = location
           self.navigationItem.rightBarButtonItem?.isEnabled = true
           self.resultLabel.text = NSLocalizedString(
             "We have successfully determined that you are in New York!",

--- a/NYPLCardCreator/Flow/UsernameAndPasswordViewController.swift
+++ b/NYPLCardCreator/Flow/UsernameAndPasswordViewController.swift
@@ -252,7 +252,8 @@ Password should be
                                         username: self.usernameCell.textField.text!,
                                         password: self.passwordCell.textField.text!,
                                         homeAddress: self.homeAddress,
-                                        workAddress: self.schoolOrWorkAddress)
+                                        workAddress: self.schoolOrWorkAddress,
+                                        location: self.configuration.user.location ?? "")
     self.navigationController?.pushViewController(
       UserSummaryViewController(
         configuration: self.configuration,

--- a/NYPLCardCreator/Helpers/CLPlacemark+LocationString.swift
+++ b/NYPLCardCreator/Helpers/CLPlacemark+LocationString.swift
@@ -1,0 +1,36 @@
+//
+//  CLPlacemark+LocationString.swift
+//  Created by Ernest Fan on 2022-01-24.
+//  Copyright © 2022 NYPL. All rights reserved.
+//
+
+import Foundation
+import CoreLocation
+
+extension CLPlacemark {
+  /// This method determines if the location is within NYC, NYS, US or none of the above,
+  /// for patron creation purpose.
+  /// - Returns: A location string, eg. nyc, nys, us or an empty string
+  func getLocationString() -> String {
+    guard isoCountryCode == "US" else {
+      return ""
+    }
+    
+    guard administrativeArea == "NY" else {
+      return "us"
+    }
+    
+    guard let postalCodeString = postalCode,
+      let postalCodeNumber = Int(postalCodeString) else {
+      return "nys"
+    }
+
+    if (10001...10499).contains(postalCodeNumber) ||
+        (11001...11499).contains(postalCodeNumber) ||
+        (11601...11699).contains(postalCodeNumber) {
+      return "nyc"
+    }
+    
+    return "nys"
+  }
+}

--- a/NYPLCardCreator/Helpers/CLPlacemark+LocationString.swift
+++ b/NYPLCardCreator/Helpers/CLPlacemark+LocationString.swift
@@ -16,7 +16,8 @@ extension CLPlacemark {
       return ""
     }
     
-    guard administrativeArea == "NY" else {
+    guard let state = administrativeArea?.lowercased(),
+          state == "ny" || state == "new york" else {
       return "us"
     }
     

--- a/NYPLCardCreatorTests/CLPlacemarkLocationStringTests.swift
+++ b/NYPLCardCreatorTests/CLPlacemarkLocationStringTests.swift
@@ -1,0 +1,165 @@
+//
+//  CLPlacemarkLocationStringTests.swift
+//  
+//  Created by Ernest Fan on 2022-01-25.
+//  Copyright © 2022 NYPL. All rights reserved.
+//
+
+import XCTest
+import CoreLocation
+@testable import NYPLCardCreator
+
+class CLPlacemarkLocationStringTests: XCTestCase {
+
+  var geoCoder: CLGeocoder!
+  
+  override func setUpWithError() throws {
+    try super.setUpWithError()
+    geoCoder = CLGeocoder()
+  }
+  
+  override func tearDownWithError() throws {
+    try super.tearDownWithError()
+    geoCoder = nil
+  }
+  
+  func testPlacemarkWithinNYC() throws {
+    let expectation = self.expectation(description: "retrivingLocation")
+    var result: [CLPlacemark]?
+    
+    // Latitude and longitude of NYPL
+    let location = CLLocation(latitude: 40.753, longitude: -73.982)
+    self.geoCoder.reverseGeocodeLocation(location) { placemarks, error in
+      if let error = error {
+        XCTFail(error.localizedDescription)
+      }
+      result = placemarks
+      expectation.fulfill()
+    }
+    
+    waitForExpectations(timeout: 3, handler: nil)
+    
+    guard let result = result else {
+      XCTFail()
+      return
+    }
+    
+    for placemark in result {
+      if placemark.getLocationString() != "nyc" {
+        XCTFail("Location string does not match address")
+      }
+    }
+  }
+  
+  func testPlacemarkWithinNYCWithAlternateCityName() throws {
+    let expectation = self.expectation(description: "retrivingLocation")
+    var result: [CLPlacemark]?
+    
+    // Latitude and longitude of Bronx
+    let location = CLLocation(latitude: 40.858, longitude: -73.885)
+    self.geoCoder.reverseGeocodeLocation(location) { placemarks, error in
+      if let error = error {
+        XCTFail(error.localizedDescription)
+      }
+      result = placemarks
+      expectation.fulfill()
+    }
+    
+    waitForExpectations(timeout: 3, handler: nil)
+    
+    guard let result = result else {
+      XCTFail()
+      return
+    }
+    
+    for placemark in result {
+      if placemark.getLocationString() != "nyc" {
+        XCTFail("Location string does not match address")
+      }
+    }
+  }
+  
+  func testPlacemarkWithinNYS() throws {
+    let expectation = self.expectation(description: "retrivingLocation")
+    var result: [CLPlacemark]?
+    
+    // Latitude and longitude of Albany
+    let location = CLLocation(latitude: 42.652, longitude: -73.756)
+    self.geoCoder.reverseGeocodeLocation(location) { placemarks, error in
+      if let error = error {
+        XCTFail(error.localizedDescription)
+      }
+      result = placemarks
+      expectation.fulfill()
+    }
+    
+    waitForExpectations(timeout: 3, handler: nil)
+    
+    guard let result = result else {
+      XCTFail()
+      return
+    }
+    
+    for placemark in result {
+      if placemark.getLocationString() != "nys" {
+        XCTFail("Location string does not match address")
+      }
+    }
+  }
+  
+  func testPlacemarkWithinUS() throws {
+    let expectation = self.expectation(description: "retrivingLocation")
+    var result: [CLPlacemark]?
+    
+    // Latitude and longitude of Seattle
+    let location = CLLocation(latitude: 47.620, longitude: -122.349)
+    self.geoCoder.reverseGeocodeLocation(location) { placemarks, error in
+      if let error = error {
+        XCTFail(error.localizedDescription)
+      }
+      result = placemarks
+      expectation.fulfill()
+    }
+    
+    waitForExpectations(timeout: 3, handler: nil)
+    
+    guard let result = result else {
+      XCTFail()
+      return
+    }
+    
+    for placemark in result {
+      if placemark.getLocationString() != "us" {
+        XCTFail("Location string does not match address")
+      }
+    }
+  }
+  
+  func testPlacemarkOutsideUS() throws {
+    let expectation = self.expectation(description: "retrivingLocation")
+    var result: [CLPlacemark]?
+    
+    // Latitude and longitude of Vancouver
+    let location = CLLocation(latitude: 49.288, longitude: -123.116)
+    self.geoCoder.reverseGeocodeLocation(location) { placemarks, error in
+      if let error = error {
+        XCTFail(error.localizedDescription)
+      }
+      result = placemarks
+      expectation.fulfill()
+    }
+    
+    waitForExpectations(timeout: 3, handler: nil)
+    
+    guard let result = result else {
+      XCTFail()
+      return
+    }
+    
+    for placemark in result {
+      if placemark.getLocationString() != "" {
+        XCTFail("Location string does not match address")
+      }
+    }
+  }
+}


### PR DESCRIPTION
**What's this do?**
Send `location` value on patron creation request

**Why are we doing this? (w/ JIRA link if applicable)**
[iOS-307](https://jira.nypl.org/browse/IOS-307)

**How should this be tested? / Do these changes have associated tests?**
Regression test on regular patron card creation

**Dependencies for merging? Releasing to production?**
N/A

**Does this include changes that require a new SimplyE/Open eBooks build for QA?**
Not yet

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@ErnestFan 
