### PR TITLE
IOS-437 Fix false positives in unit tests runs

### DIFF
--- a/.github/workflows/unit-testing.yml
+++ b/.github/workflows/unit-testing.yml
@@ -5,11 +5,11 @@ jobs:
   build-and-test:
     runs-on: macOS-latest
     steps:
-      - name: Force Xcode 13.1
-        run: sudo xcode-select -switch /Applications/Xcode_13.1.app
+      - name: Force latest Xcode #currently 13.2.1 cos 13.3.1 still in beta at github; once ready for prod the Xcode.app symlink will automatically select it
+        run: ls -la /Applications && sudo xcode-select -switch /Applications/Xcode.app
       - name: Print System Architecture
         run: uname -a
       - name: Checkout main repo and submodules
         uses: actions/checkout@v2
       - name: Run SPM Unit Tests
-        run: xcodebuild -scheme 'NYPLCardCreator' -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPad mini (6th generation)' test | if command -v xcpretty; then xcpretty; else cat; fi
+        run: ./scripts/run-unittests.sh

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,7 +6,7 @@
         "repositoryURL": "https://github.com/NYPL-Simplified/iOS-Utilities.git",
         "state": {
           "branch": "main",
-          "revision": "39ec99cdfc598da0984a3a51329df41a3e6a7612",
+          "revision": "ed011c9fa109ed306e9c9d30fd2552aa8bf832fe",
           "version": null
         }
       },

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 NYPLCardCreator provides a native iOS implementation of the tool used to create NYPL library cards. 
 
+# Unit Testing
+
+`./scripts/run-unittests.sh`
+
 # Dependencies
 
 - [NYPLUtilities](https://github.com/NYPL-Simplified/iOS-Utilities)

--- a/scripts/run-unittests.sh
+++ b/scripts/run-unittests.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -o pipefail
+set -e
+
+xcodebuild -scheme 'NYPLCardCreator' -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPad mini (6th generation)' test | if command -v xcpretty; then xcpretty; else cat; fi


### PR DESCRIPTION
the problem was that the inline script contained a pipe for xcpretty and that swallowed the error from the xcodebuild command.